### PR TITLE
added no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ default-features = false
 [dependencies.num-traits]
 version = "0.2.1"
 default-features = false
-features = ["std"]
 
 [dependencies.rustc-serialize]
 optional = true
@@ -37,5 +36,6 @@ optional = true
 version = ">= 0.7.0, < 0.9.0"
 
 [features]
-default = ["bigint", "rustc-serialize"]
-bigint = ["num-bigint"]
+default = ["bigint", "rustc-serialize", "std"]
+bigint = ["num-bigint", "std"]
+std = ["num-traits/std"]

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ version = "0.2"
 default-features = false
 ```
 
-`FromPrimitive` implementations are only available when `std` is enabled.
-
 ## Releases
 
 Release notes are available in [RELEASES.md](RELEASES.md).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-num-rational = "0.1"
+num-rational = "0.2"
 ```
 
 and this to your crate root:
@@ -21,6 +21,19 @@ and this to your crate root:
 ```rust
 extern crate num_rational;
 ```
+
+## Features
+
+This crate can be used without the standard library (`#![no_std]`) by disabling
+the default `std` feature.  Use this in `Cargo.toml`:
+
+```toml
+[dependencies.num-rational]
+version = "0.2"
+default-features = false
+```
+
+`FromPrimitive` implementations are only available when `std` is enabled.
 
 ## Releases
 

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -13,7 +13,7 @@ cargo build --no-default-features
 cargo test --no-default-features
 
 # Each isolated feature should also work everywhere.
-for feature in bigint rustc-serialize serde; do
+for feature in bigint rustc-serialize serde std; do
   cargo build --verbose --no-default-features --features="$feature"
   cargo test --verbose --no-default-features --features="$feature"
 done

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,8 @@ use bigint::{BigInt, BigUint, Sign};
 use integer::Integer;
 use traits::float::FloatCore;
 use traits::{FromPrimitive, PrimInt, Num, Signed, Zero, One, Bounded, Inv, NumCast, CheckedAdd, CheckedSub, CheckedMul, CheckedDiv};
+#[cfg(feature = "std")]
+use traits::Float;
 
 /// Represents the ratio between 2 numbers.
 #[derive(Copy, Clone, Debug)]
@@ -783,7 +785,7 @@ impl<T: Clone + Integer> Num for Ratio<T> {
             if denom.is_zero() {
                 Err(ParseRatioError { kind: RatioErrorKind::ZeroDenominator })
             } else {
-                Ok(Ratio::new(numer.clone(), denom.clone()))
+                Ok(Ratio::new(numer, denom))
             }
         } else {
             Err(ParseRatioError { kind: RatioErrorKind::ParseError })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -918,10 +918,9 @@ enum RatioErrorKind {
     ZeroDenominator,
 }
 
-#[cfg(feature = "std")]
 impl fmt::Display for ParseRatioError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
+        self.kind.description().fmt(f)
     }
 }
 
@@ -932,7 +931,6 @@ impl Error for ParseRatioError {
     }
 }
 
-#[cfg(feature = "std")]
 impl RatioErrorKind {
     fn description(&self) -> &'static str {
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1133,6 +1133,7 @@ fn approximate_float_unsigned<T, F>(val: F, max_error: F, max_iterations: usize)
 }
 
 #[cfg(test)]
+#[cfg(feature = "std")]
 fn hash<T: Hash>(x: &T) -> u64 {
     use std::hash::BuildHasher;
     use std::collections::hash_map::RandomState;
@@ -1147,8 +1148,10 @@ mod test {
     #[cfg(feature = "num-bigint")]
     use super::BigRational;
 
+    #[cfg(feature = "std")]
     use std::str::FromStr;
-    use std::i32;
+    use core::i32;
+    #[cfg(feature = "std")]
     use std::f64;
     use traits::{Zero, One, Signed, FromPrimitive};
 
@@ -1241,6 +1244,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_approximate_float() {
         assert_eq!(Ratio::from_f32(0.5f32), Some(Ratio::new(1i64, 2)));
         assert_eq!(Ratio::from_f64(0.5f64), Some(Ratio::new(1i32, 2)));
@@ -1288,6 +1292,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_cmp_overflow() {
         use std::cmp::Ordering;
 
@@ -1367,6 +1372,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_show() {
         assert_eq!(format!("{}", _2), "2".to_string());
         assert_eq!(format!("{}", _1_2), "1/2".to_string());
@@ -1614,6 +1620,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_to_from_str() {
         fn test(r: Rational, s: String) {
             assert_eq!(FromStr::from_str(&s), Ok(r));
@@ -1627,6 +1634,7 @@ mod test {
         test(_NEG1_2, "-1/2".to_string());
     }
     #[test]
+    #[cfg(feature = "std")]
     fn test_from_str_fail() {
         fn test(s: &str) {
             let rational: Result<Rational, _> = FromStr::from_str(s);
@@ -1639,8 +1647,8 @@ mod test {
         }
     }
 
-    #[cfg(feature = "num-bigint")]
     #[test]
+    #[cfg(feature = "num-bigint")]
     fn test_from_float() {
         use traits::Float;
         fn test<T: Float>(given: T, (numer, denom): (&str, &str)) {
@@ -1703,6 +1711,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_hash() {
         assert!(::hash(&_0) != ::hash(&_1));
         assert!(::hash(&_0) != ::hash(&_3_2));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1271,9 +1271,8 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "std")]
     fn test_cmp_overflow() {
-        use std::cmp::Ordering;
+        use core::cmp::Ordering;
 
         // issue #7 example:
         let big = Ratio::new(128u8, 1);
@@ -1282,7 +1281,7 @@ mod test {
 
         // try a few that are closer together
         // (some matching numer, some matching denom, some neither)
-        let ratios = vec![
+        let ratios = [
             Ratio::new(125_i8, 127_i8),
             Ratio::new(63_i8, 64_i8),
             Ratio::new(124_i8, 125_i8),
@@ -1292,6 +1291,7 @@ mod test {
         ];
 
         fn check_cmp(a: Ratio<i8>, b: Ratio<i8>, ord: Ordering) {
+            #[cfg(feature = "std")]
             println!("comparing {} and {}", a, b);
             assert_eq!(a.cmp(&b), ord);
             assert_eq!(b.cmp(&a), ord.reverse());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ use traits::Float;
 
 /// Represents the ratio between 2 numbers.
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(all(feature = "std", feature = "rustc-serialize"), derive(RustcEncodable, RustcDecodable))]
 #[allow(missing_docs)]
 pub struct Ratio<T> {
     numer: T,


### PR DESCRIPTION
Currently the `uom` crate (and who knows what other crates) cannot support no_std because it depends deeply on num-rational, so I'm adding no_std support here.  Feedback definitely welcome, I'm brand new to Rust and I know I have a lot to learn.