### PR TITLE
impl std::iter::{Sum, Product} for Ratio

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1177,6 +1177,7 @@ mod test {
     use core::i32;
     use core::f64;
     use traits::{Zero, One, Signed, FromPrimitive};
+    use integer::Integer;
 
     pub const _0: Rational = Ratio {
         numer: 0,
@@ -1762,5 +1763,56 @@ mod test {
         assert_eq! (_1, Ratio::from ((1, 1)));
         assert_eq! (_NEG2, Ratio::from ((-2, 1)));
         assert_eq! (_1_NEG2, Ratio::from ((1, -2)));
+    }
+
+    #[test]
+    fn ratio_iter_sum() {
+        // generic function to assure the iter method can be called
+        // for any Iterator with Item = Ratio<impl Integer> or Ratio<&impl Integer>
+        fn iter_sums<T: Integer + Clone>(slice: &[Ratio<T>]) -> [Ratio<T>; 3] {
+            let mut manual_sum = Ratio::new(T::zero(), T::one());
+            for ratio in slice {
+                manual_sum = manual_sum + ratio;
+            }
+            [
+                manual_sum,
+                slice.iter().sum(),
+                slice.iter().cloned().sum()
+            ]
+        }
+        // collect into array so test works on no_std
+        let mut nums = [Ratio::new(0,1); 1000];
+        for (i, r) in (0..1000).map(|n| Ratio::new(n, 500)).enumerate() {
+            nums[i] = r;
+        }
+        let sums = iter_sums(&nums[..]);
+        assert_eq!(sums[0], sums[1]);
+        assert_eq!(sums[0], sums[2]);
+    }
+
+    #[test]
+    fn ratio_iter_product() {
+        // generic function to assure the iter method can be called
+        // for any Iterator with Item = Ratio<impl Integer> or Ratio<&impl Integer>
+        fn iter_products<T: Integer + Clone>(slice: &[Ratio<T>]) -> [Ratio<T>; 3] {
+            let mut manual_prod = Ratio::new(T::one(), T::one());
+            for ratio in slice {
+                manual_prod = manual_prod * ratio;
+            }
+            [
+                manual_prod,
+                slice.iter().product(),
+                slice.iter().cloned().product()
+            ]
+        }
+
+        // collect into array so test works on no_std
+        let mut nums = [Ratio::new(0,1); 1000];
+        for (i, r) in (0..1000).map(|n| Ratio::new(n, 500)).enumerate() {
+            nums[i] = r;
+        }
+        let products = iter_products(&nums[..]);
+        assert_eq!(products[0], products[1]);
+        assert_eq!(products[0], products[2]);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/rust-num/num-rational/issues/3

I only implemented `Sum` and `Product` for `Ratio<T>` and `&Ratio<T>` rather than any `U, where Ratio<T>: Mul<U, Output = Ratio<T>>`. Summing for example an iter of `T` directly into a `Ratio<T>` does not seem like particularly useful or critical functionality.