### PR TITLE
Avoid overflow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1592,6 +1592,7 @@ mod test {
         use super::{to_big, _0, _1, _1_2, _2, _3_2, _5_2, _NEG1_2};
         use core::fmt::Debug;
         use integer::Integer;
+        #[cfg(feature = "std")]
         use std::panic::{catch_unwind, AssertUnwindSafe};
         use traits::{Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, NumAssign};
 
@@ -1783,7 +1784,9 @@ mod test {
                 let big = T::max_value() / two.clone() / two.clone() * two.clone();
                 let _1_big: Ratio<T> = Ratio::new(T::one(), big.clone());
                 let _2_3: Ratio<T> = Ratio::new(two.clone(), _3.clone());
-                assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
+                if cfg!(std) {
+                    assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
+                }
                 let expected = Ratio::new(T::one(), big / two.clone() * _3.clone());
                 assert_eq!(expected.clone(), _1_big.clone() * _2_3.clone());
                 assert_eq!(expected, {
@@ -1795,7 +1798,9 @@ mod test {
                 // big/3 * 3 = big/1
                 // make big = max/2, but make it indivisible by 3
                 let big = T::max_value() / two.clone() / _3.clone() * _3.clone() + T::one();
-                assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
+                if cfg!(std) {
+                    assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
+                }
                 let big_3 = Ratio::new(big.clone(), _3.clone());
                 let expected = Ratio::new(big.clone(), T::one());
                 assert_eq!(expected, big_3.clone() * _3.clone());
@@ -1868,7 +1873,9 @@ mod test {
                 // 1/big / 3/2 = 1/(max/4*3), where big is max/2
                 // big ~ max/2, and big is divisible by 2
                 let big = T::max_value() / two.clone() / two.clone() * two.clone();
-                assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
+                if cfg!(std) {
+                    assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
+                }
                 let _1_big: Ratio<T> = Ratio::new(T::one(), big.clone());
                 let _3_two: Ratio<T> = Ratio::new(_3.clone(), two.clone());
                 let expected = Ratio::new(T::one(), big.clone() / two.clone() * _3.clone());
@@ -1882,7 +1889,9 @@ mod test {
                 // 3/big / 3 = 1/big where big is max/2
                 // big ~ max/2, and big is not divisible by 3
                 let big = T::max_value() / two.clone() / _3.clone() * _3.clone() + T::one();
-                assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
+                if cfg!(std) {
+                    assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
+                }
                 let _3_big = Ratio::new(_3.clone(), big.clone());
                 let expected = Ratio::new(T::one(), big.clone());
                 assert_eq!(expected, _3_big.clone() / _3.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1592,8 +1592,6 @@ mod test {
         use super::{to_big, _0, _1, _1_2, _2, _3_2, _5_2, _NEG1_2};
         use core::fmt::Debug;
         use integer::Integer;
-        #[cfg(feature = "std")]
-        use std::panic::{catch_unwind, AssertUnwindSafe};
         use traits::{Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, NumAssign};
 
         #[test]
@@ -1774,7 +1772,7 @@ mod test {
         fn test_mul_overflow() {
             fn test_mul_typed_overflow<T>()
             where
-                T: Integer + Bounded + Clone + Debug + NumAssign,
+                T: Integer + Bounded + Clone + Debug + NumAssign + CheckedMul,
             {
                 let two = T::one() + T::one();
                 let _3 = T::one() + T::one() + T::one();
@@ -1784,9 +1782,7 @@ mod test {
                 let big = T::max_value() / two.clone() / two.clone() * two.clone();
                 let _1_big: Ratio<T> = Ratio::new(T::one(), big.clone());
                 let _2_3: Ratio<T> = Ratio::new(two.clone(), _3.clone());
-                if cfg!(std) {
-                    assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
-                }
+                assert_eq!(None, big.clone().checked_mul(&_3.clone()));
                 let expected = Ratio::new(T::one(), big / two.clone() * _3.clone());
                 assert_eq!(expected.clone(), _1_big.clone() * _2_3.clone());
                 assert_eq!(expected, {
@@ -1798,9 +1794,7 @@ mod test {
                 // big/3 * 3 = big/1
                 // make big = max/2, but make it indivisible by 3
                 let big = T::max_value() / two.clone() / _3.clone() * _3.clone() + T::one();
-                if cfg!(std) {
-                    assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
-                }
+                assert_eq!(None, big.clone().checked_mul(&_3.clone()));
                 let big_3 = Ratio::new(big.clone(), _3.clone());
                 let expected = Ratio::new(big.clone(), T::one());
                 assert_eq!(expected, big_3.clone() * _3.clone());
@@ -1865,7 +1859,7 @@ mod test {
         fn test_div_overflow() {
             fn test_div_typed_overflow<T>()
             where
-                T: Integer + Bounded + Clone + Debug + NumAssign,
+                T: Integer + Bounded + Clone + Debug + NumAssign + CheckedMul,
             {
                 let two = T::one() + T::one();
                 let _3 = T::one() + T::one() + T::one();
@@ -1873,9 +1867,7 @@ mod test {
                 // 1/big / 3/2 = 1/(max/4*3), where big is max/2
                 // big ~ max/2, and big is divisible by 2
                 let big = T::max_value() / two.clone() / two.clone() * two.clone();
-                if cfg!(std) {
-                    assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
-                }
+                assert_eq!(None, big.clone().checked_mul(&_3.clone()));
                 let _1_big: Ratio<T> = Ratio::new(T::one(), big.clone());
                 let _3_two: Ratio<T> = Ratio::new(_3.clone(), two.clone());
                 let expected = Ratio::new(T::one(), big.clone() / two.clone() * _3.clone());
@@ -1889,9 +1881,7 @@ mod test {
                 // 3/big / 3 = 1/big where big is max/2
                 // big ~ max/2, and big is not divisible by 3
                 let big = T::max_value() / two.clone() / _3.clone() * _3.clone() + T::one();
-                if cfg!(std) {
-                    assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
-                }
+                assert_eq!(None, big.clone().checked_mul(&_3.clone()));
                 let _3_big = Ratio::new(_3.clone(), big.clone());
                 let expected = Ratio::new(T::one(), big.clone());
                 assert_eq!(expected, _3_big.clone() / _3.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -820,10 +820,10 @@ macro_rules! checked_arith_impl {
             #[inline]
             fn $method(&self, rhs: &Ratio<T>) -> Option<Ratio<T>> {
                 let gcd = self.denom.clone().gcd(&rhs.denom.clone());
-                let lcm = (self.denom.clone() / gcd.clone()).checked_mul(&rhs.denom)?;
-                let lhs_numer = (lcm.clone() / self.denom.clone()).checked_mul(&self.numer)?;
-                let rhs_numer = (lcm.clone() / rhs.denom.clone()).checked_mul(&rhs.numer)?;
-                Some(Ratio::new(lhs_numer.$method(&rhs_numer)?, lcm))
+                let lcm = otry!((self.denom.clone() / gcd.clone()).checked_mul(&rhs.denom));
+                let lhs_numer = otry!((lcm.clone() / self.denom.clone()).checked_mul(&self.numer));
+                let rhs_numer = otry!((lcm.clone() / rhs.denom.clone()).checked_mul(&rhs.numer));
+                Some(Ratio::new(otry!(lhs_numer.$method(&rhs_numer)), lcm))
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,9 +506,11 @@ mod opassign {
 
     impl<T: Clone + Integer + NumAssign> AddAssign for Ratio<T> {
         fn add_assign(&mut self, other: Ratio<T>) {
-            self.numer *= other.denom.clone();
-            self.numer += self.denom.clone() * other.numer;
-            self.denom *= other.denom;
+            let lcm = self.denom.lcm(&other.denom.clone());
+            let lhs_numer = self.numer.clone() * (lcm.clone() / self.denom.clone());
+            let rhs_numer = other.numer * (lcm.clone() / other.denom);
+            self.numer = lhs_numer + rhs_numer;
+            self.denom = lcm;
             self.reduce();
         }
     }
@@ -531,18 +533,22 @@ mod opassign {
 
     impl<T: Clone + Integer + NumAssign> RemAssign for Ratio<T> {
         fn rem_assign(&mut self, other: Ratio<T>) {
-            self.numer *= other.denom.clone();
-            self.numer %= self.denom.clone() * other.numer;
-            self.denom *= other.denom;
+            let lcm = self.denom.lcm(&other.denom.clone());
+            let lhs_numer = self.numer.clone() * (lcm.clone() / self.denom.clone());
+            let rhs_numer = other.numer * (lcm.clone() / other.denom);
+            self.numer = lhs_numer % rhs_numer;
+            self.denom = lcm;
             self.reduce();
         }
     }
 
     impl<T: Clone + Integer + NumAssign> SubAssign for Ratio<T> {
         fn sub_assign(&mut self, other: Ratio<T>) {
-            self.numer *= other.denom.clone();
-            self.numer -= self.denom.clone() * other.numer;
-            self.denom *= other.denom;
+            let lcm = self.denom.lcm(&other.denom.clone());
+            let lhs_numer = self.numer.clone() * (lcm.clone() / self.denom.clone());
+            let rhs_numer = other.numer * (lcm.clone() / other.denom);
+            self.numer = lhs_numer - rhs_numer;
+            self.denom = lcm;
             self.reduce();
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1592,6 +1592,7 @@ mod test {
         use super::{to_big, _0, _1, _1_2, _2, _3_2, _5_2, _NEG1_2};
         use core::fmt::Debug;
         use integer::Integer;
+        use std::panic::{catch_unwind, AssertUnwindSafe};
         use traits::{Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, NumAssign};
 
         #[test]
@@ -1790,13 +1791,15 @@ mod test {
             where
                 T: Integer + Bounded + Clone + Debug + NumAssign,
             {
-                // 1/big * 2/3 = 1/(max/4*3), where big is max/2
                 let two = T::one() + T::one();
                 let _3 = T::one() + T::one() + T::one();
+
+                // 1/big * 2/3 = 1/(max/4*3), where big is max/2
                 // make big = max/2, but also divisible by 2
                 let big = T::max_value() / two.clone() / two.clone() * two.clone();
                 let _1_big: Ratio<T> = Ratio::new(T::one(), big.clone());
                 let _2_3: Ratio<T> = Ratio::new(two.clone(), _3.clone());
+                assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
                 let expected = Ratio::new(T::one(), big / two.clone() * _3.clone());
                 assert_eq!(expected.clone(), _1_big.clone() * _2_3.clone());
                 let mut tmp = _1_big.clone();
@@ -1806,6 +1809,7 @@ mod test {
                 // big/3 * 3 = big/1
                 // make big = max/2, but make it indivisible by 3
                 let big = T::max_value() / two.clone() / _3.clone() * _3.clone() + T::one();
+                assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
                 let big_3 = Ratio::new(big.clone(), _3.clone());
                 let expected = Ratio::new(big.clone(), T::one());
                 assert_eq!(expected, big_3.clone() * _3.clone());
@@ -1870,11 +1874,13 @@ mod test {
             where
                 T: Integer + Bounded + Clone + Debug + NumAssign,
             {
-                // 1/big / 3/2 = 1/(max/4*3), where big is max/2
                 let two = T::one() + T::one();
                 let _3 = T::one() + T::one() + T::one();
+
+                // 1/big / 3/2 = 1/(max/4*3), where big is max/2
                 // big ~ max/2, and big is divisible by 2
                 let big = T::max_value() / two.clone() / two.clone() * two.clone();
+                assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
                 let _1_big: Ratio<T> = Ratio::new(T::one(), big.clone());
                 let _3_two: Ratio<T> = Ratio::new(_3.clone(), two.clone());
                 let expected = Ratio::new(T::one(), big.clone() / two.clone() * _3.clone());
@@ -1886,6 +1892,7 @@ mod test {
                 // 3/big / 3 = 1/big where big is max/2
                 // big ~ max/2, and big is not divisible by 3
                 let big = T::max_value() / two.clone() / _3.clone() * _3.clone() + T::one();
+                assert!(catch_unwind(AssertUnwindSafe(|| big.clone() * _3.clone())).is_err());
                 let _3_big = Ratio::new(_3.clone(), big.clone());
                 let expected = Ratio::new(T::one(), big.clone());
                 assert_eq!(expected, _3_big.clone() / _3.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,7 +509,7 @@ mod opassign {
             if self.denom == other.denom {
                 self.numer += other.numer
             } else {
-                let lcm = self.denom.lcm(&other.denom.clone());
+                let lcm = self.denom.lcm(&other.denom);
                 let lhs_numer = self.numer.clone() * (lcm.clone() / self.denom.clone());
                 let rhs_numer = other.numer * (lcm.clone() / other.denom);
                 self.numer = lhs_numer + rhs_numer;
@@ -522,12 +522,12 @@ mod opassign {
     // (a/b) / (c/d) = (a/gcd_ac)*(d/gcd_bd) / ((c/gcd_ac)*(b/gcd_bd))
     impl<T: Clone + Integer + NumAssign> DivAssign for Ratio<T> {
         fn div_assign(&mut self, other: Ratio<T>) {
-            let gcd_ac = self.numer.gcd(&other.numer.clone());
-            let gcd_bd = self.denom.gcd(&other.denom.clone());
+            let gcd_ac = self.numer.gcd(&other.numer);
+            let gcd_bd = self.denom.gcd(&other.denom);
             self.numer /= gcd_ac.clone();
             self.numer *= other.denom / gcd_bd.clone();
-            self.denom /= gcd_bd.clone();
-            self.denom *= other.numer / gcd_ac.clone();
+            self.denom /= gcd_bd;
+            self.denom *= other.numer / gcd_ac;
             self.reduce(); //TODO: remove this line. see #8.
         }
     }
@@ -535,8 +535,8 @@ mod opassign {
     // a/b * c/d = (a/gcd_ad)*(c/gcd_bc) / ((d/gcd_ad)*(b/gcd_bc))
     impl<T: Clone + Integer + NumAssign> MulAssign for Ratio<T> {
         fn mul_assign(&mut self, other: Ratio<T>) {
-            let gcd_ad = self.numer.gcd(&other.denom.clone());
-            let gcd_bc = self.denom.gcd(&other.numer.clone());
+            let gcd_ad = self.numer.gcd(&other.denom);
+            let gcd_bc = self.denom.gcd(&other.numer);
             self.numer /= gcd_ad.clone();
             self.numer *= other.numer / gcd_bc.clone();
             self.denom /= gcd_bc;
@@ -550,7 +550,7 @@ mod opassign {
             if self.denom == other.denom {
                 self.numer %= other.numer
             } else {
-                let lcm = self.denom.lcm(&other.denom.clone());
+                let lcm = self.denom.lcm(&other.denom);
                 let lhs_numer = self.numer.clone() * (lcm.clone() / self.denom.clone());
                 let rhs_numer = other.numer * (lcm.clone() / other.denom);
                 self.numer = lhs_numer % rhs_numer;
@@ -565,7 +565,7 @@ mod opassign {
             if self.denom == other.denom {
                 self.numer -= other.numer
             } else {
-                let lcm = self.denom.lcm(&other.denom.clone());
+                let lcm = self.denom.lcm(&other.denom);
                 let lhs_numer = self.numer.clone() * (lcm.clone() / self.denom.clone());
                 let rhs_numer = other.numer * (lcm.clone() / other.denom);
                 self.numer = lhs_numer - rhs_numer;
@@ -734,8 +734,8 @@ where
     type Output = Ratio<T>;
     #[inline]
     fn mul(self, rhs: Ratio<T>) -> Ratio<T> {
-        let gcd_ad = self.numer.gcd(&rhs.denom.clone());
-        let gcd_bc = self.denom.gcd(&rhs.numer.clone());
+        let gcd_ad = self.numer.gcd(&rhs.denom);
+        let gcd_bc = self.denom.gcd(&rhs.numer);
         Ratio::new(
             self.numer / gcd_ad.clone() * (rhs.numer / gcd_bc.clone()),
             self.denom / gcd_bc * (rhs.denom / gcd_ad),
@@ -751,7 +751,7 @@ where
     #[inline]
     fn mul(self, rhs: T) -> Ratio<T> {
         let gcd = self.denom.gcd(&rhs);
-        Ratio::new(self.numer * (rhs / gcd.clone()), self.denom / gcd.clone())
+        Ratio::new(self.numer * (rhs / gcd.clone()), self.denom / gcd)
     }
 }
 
@@ -798,7 +798,7 @@ macro_rules! arith_impl {
                 if self.denom == rhs.denom {
                     return Ratio::new(self.numer.$method(rhs.numer), rhs.denom);
                 }
-                let lcm = self.denom.lcm(&rhs.denom.clone());
+                let lcm = self.denom.lcm(&rhs.denom);
                 let lhs_numer = self.numer * (lcm.clone() / self.denom);
                 let rhs_numer = rhs.numer * (lcm.clone() / rhs.denom);
                 Ratio::new(lhs_numer.$method(rhs_numer), lcm)
@@ -874,7 +874,7 @@ macro_rules! checked_arith_impl {
         impl<T: Clone + Integer + CheckedMul + $imp> $imp for Ratio<T> {
             #[inline]
             fn $method(&self, rhs: &Ratio<T>) -> Option<Ratio<T>> {
-                let gcd = self.denom.clone().gcd(&rhs.denom.clone());
+                let gcd = self.denom.clone().gcd(&rhs.denom);
                 let lcm = otry!((self.denom.clone() / gcd.clone()).checked_mul(&rhs.denom));
                 let lhs_numer = otry!((lcm.clone() / self.denom.clone()).checked_mul(&self.numer));
                 let rhs_numer = otry!((lcm.clone() / rhs.denom.clone()).checked_mul(&rhs.numer));


### PR DESCRIPTION
fix #13 

this addresses the fact that 1/255 as `Rational<u8>` + 1/255 as `Rational<u8>` caused an overflow even though 2/255 is representable as a `Rational<u8>`. This overflow also occured for subtraction and modulo, as these are implemented with the same macro. This PR addresses the issue by calculating the LCM of denominators rather than naively multiplying denominators, then simplifying. Basically pre-simplify, then add, rather than add then simplify. As a comment reads, `Abstracts a/b op c/d = (a*lcm/b op c*lcm/d)/lcm where lcm = lcm(b,d)` (in this case op is exactly +,- and %)

The performance penalties of this approach have not been measured, but I would expect it to be a moderate performance regression for word-sized integer types, as calculating LCM is O(logn) whereas the naive approach requires only multiplication and addition, O(1).

For BigInts, I expect the performance regression to be minimal, as the old approach required multiplication, O(nlogn)? While calculating the LCM is also O(nlogn) for BigInts.