### PR TITLE
Fix #49

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,6 +385,9 @@ impl<T: Clone + Integer> Ord for Ratio<T> {
 
         // With equal numerators, the denominators can be inversely compared
         if self.numer == other.numer {
+            if T::is_zero(self.numer()) {
+                return cmp::Ordering::Equal;
+            }
             let ord = self.denom.cmp(&other.denom);
             return if self.numer < T::zero() {
                 ord
@@ -1446,6 +1449,9 @@ mod test {
 
         assert!(_0 >= _0 && _1 >= _1);
         assert!(_1 >= _0 && !(_0 >= _1));
+
+        let _0_2: Rational = Ratio::new_raw(0, 2);
+        assert_eq!(_0, _0_2);
     }
 
     #[test]
@@ -1538,7 +1544,7 @@ mod test {
 
     mod arith {
         use super::super::{Ratio, Rational};
-        use super::{_0, _1, _1_2, _2, _3_2, _NEG1_2, to_big};
+        use super::{to_big, _0, _1, _1_2, _2, _3_2, _NEG1_2};
         use traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 
         #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,7 @@ impl<T: Clone + Integer> Ord for Ratio<T> {
 
         // With equal numerators, the denominators can be inversely compared
         if self.numer == other.numer {
-            if T::is_zero(self.numer()) {
+            if self.numer.is_zero() {
                 return cmp::Ordering::Equal;
             }
             let ord = self.denom.cmp(&other.denom);


### PR DESCRIPTION
fixed issue #49 
added a test case for it

Side note:
`cmp` is a bit scary. Do we know what it's amortized runtime is? It seems to me that the worst case (having to compare the reciprocals many times) could  be pretty bad. Is there any way to have a separate `impl` for `T: Clone + Integer + CheckedMul`? As the comments note, CheckedMul would make the implementation faster. I messed around, but I can't find a way to have two implementations -- one for checked and one for no checked. I found an [this](https://github.com/rust-lang/rfcs/pull/586) RFC for negative trait bounds though (spoiler: negative trait bounds are not happening soon).