### PR TITLE
add more formatting traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,6 @@ default = ["bigint-std", "std"]
 std = ["num-integer/std", "num-traits/std"]
 bigint = ["num-bigint"]
 bigint-std = ["bigint", "num-bigint/std"]
+
+[build-dependencies]
+autocfg = "1.0.0"

--- a/build.rs
+++ b/build.rs
@@ -1,16 +1,17 @@
 fn main() {
     let ac = autocfg::new();
     if ac.probe_expression("format!(\"{:e}\", 0_i32)") {
-        if !(ac.probe_expression("format!(\"{:e}\", 0_i8)") &&
-        ac.probe_expression("format!(\"{:e}\", 0_i16)") &&
-        ac.probe_expression("format!(\"{:e}\", 0_i32)") &&
-        ac.probe_expression("format!(\"{:e}\", 0_i64)") &&
-        ac.probe_expression("format!(\"{:e}\", 0_i128)") &&
-        ac.probe_expression("format!(\"{:e}\", 0_u8)") &&
-        ac.probe_expression("format!(\"{:e}\", 0_u16)") &&
-        ac.probe_expression("format!(\"{:e}\", 0_u32)") &&
-        ac.probe_expression("format!(\"{:e}\", 0_u64)") &&
-        ac.probe_expression("format!(\"{:e}\", 0_u128)")) {
+        if !(ac.probe_expression("format!(\"{:e}\", 0_i8)")
+            && ac.probe_expression("format!(\"{:e}\", 0_i16)")
+            && ac.probe_expression("format!(\"{:e}\", 0_i32)")
+            && ac.probe_expression("format!(\"{:e}\", 0_i64)")
+            && ac.probe_expression("format!(\"{:e}\", 0_i128)")
+            && ac.probe_expression("format!(\"{:e}\", 0_u8)")
+            && ac.probe_expression("format!(\"{:e}\", 0_u16)")
+            && ac.probe_expression("format!(\"{:e}\", 0_u32)")
+            && ac.probe_expression("format!(\"{:e}\", 0_u64)")
+            && ac.probe_expression("format!(\"{:e}\", 0_u128)"))
+        {
             panic!("Some integer types implement *Exp traits, but not others")
         }
         println!("cargo:rustc-cfg=has_int_exp_fmt");

--- a/build.rs
+++ b/build.rs
@@ -1,19 +1,6 @@
 fn main() {
     let ac = autocfg::new();
-    if ac.probe_expression("format!(\"{:e}\", 0_i32)") {
-        if !(ac.probe_expression("format!(\"{:e}\", 0_i8)")
-            && ac.probe_expression("format!(\"{:e}\", 0_i16)")
-            && ac.probe_expression("format!(\"{:e}\", 0_i32)")
-            && ac.probe_expression("format!(\"{:e}\", 0_i64)")
-            && ac.probe_expression("format!(\"{:e}\", 0_i128)")
-            && ac.probe_expression("format!(\"{:e}\", 0_u8)")
-            && ac.probe_expression("format!(\"{:e}\", 0_u16)")
-            && ac.probe_expression("format!(\"{:e}\", 0_u32)")
-            && ac.probe_expression("format!(\"{:e}\", 0_u64)")
-            && ac.probe_expression("format!(\"{:e}\", 0_u128)"))
-        {
-            panic!("Some integer types implement *Exp traits, but not others")
-        }
+    if ac.probe_expression("format!(\"{:e}\", 0_isize)") {
         println!("cargo:rustc-cfg=has_int_exp_fmt");
     }
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,20 @@
+fn main() {
+    let ac = autocfg::new();
+    if ac.probe_expression("format!(\"{:e}\", 0_i32)") {
+        if !(ac.probe_expression("format!(\"{:e}\", 0_i8)") &&
+        ac.probe_expression("format!(\"{:e}\", 0_i16)") &&
+        ac.probe_expression("format!(\"{:e}\", 0_i32)") &&
+        ac.probe_expression("format!(\"{:e}\", 0_i64)") &&
+        ac.probe_expression("format!(\"{:e}\", 0_i128)") &&
+        ac.probe_expression("format!(\"{:e}\", 0_u8)") &&
+        ac.probe_expression("format!(\"{:e}\", 0_u16)") &&
+        ac.probe_expression("format!(\"{:e}\", 0_u32)") &&
+        ac.probe_expression("format!(\"{:e}\", 0_u64)") &&
+        ac.probe_expression("format!(\"{:e}\", 0_u128)")) {
+            panic!("Some integer types implement *Exp traits, but not others")
+        }
+        println!("cargo:rustc-cfg=has_int_exp_fmt");
+    }
+
+    autocfg::rerun_path(file!());
+}

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -13,9 +13,9 @@ then RUST_VERSION=$(get_rust_version)  # we're not in travis
 else RUST_VERSION=$TRAVIS_RUST_VERSION  # we're in travis
 fi
 
-if [ -z ${RUST_VERSION} ]
+if [ -z "${RUST_VERSION}" ]
 then  echo "WARNING: RUST_VERSION is undefined or empty string" 1>&2
-else  echo Testing num-rational on rustc ${RUST_VERSION}
+else  echo Testing num-rational on rustc "${RUST_VERSION}"
 fi
 
 set -x

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -1,12 +1,28 @@
 #!/bin/bash
 
-set -ex
+set -e
 
-echo Testing num-rational on rustc ${TRAVIS_RUST_VERSION}
+get_rust_version() {
+  local array=($(rustc --version));
+  echo "${array[1]}";
+  return 0;
+}
+
+if [ -z ${TRAVIS+x} ]
+then RUST_VERSION=$(get_rust_version)  # we're not in travis
+else RUST_VERSION=$TRAVIS_RUST_VERSION  # we're in travis
+fi
+
+if [ -z ${RUST_VERSION} ]
+then  echo "WARNING: RUST_VERSION is undefined or empty string" 1>&2
+else  echo Testing num-rational on rustc ${RUST_VERSION}
+fi
+
+set -x
 
 STD_FEATURES="bigint-std serde"
 
-case "$TRAVIS_RUST_VERSION" in
+case "$RUST_VERSION" in
   1.3[1-5].*) NO_STD_FEATURES="serde" ;;
   *) NO_STD_FEATURES="bigint serde" ;;
 esac

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1604,9 +1604,7 @@ mod test {
     }
 
     #[cfg(not(feature = "std"))]
-    use core::fmt;
-    #[cfg(not(feature = "std"))]
-    use fmt::Write;
+    use core::fmt::{self, Write};
     #[cfg(not(feature = "std"))]
     const TESTER_BUF_SIZE: usize = 32;
     #[cfg(not(feature = "std"))]
@@ -1734,15 +1732,15 @@ mod test {
             numer: 1.0_f32,
             denom: 3.14159e38,
         };
-        assert_eq!(&format!("{:e}", _one_tehth_1_f), "1e-1");
-        assert_eq!(&format!("{:#e}", _one_tehth_1_f), "1e-1");
+        assert_eq!(&format!("{:e}", _one_tenth_1_f), "1e-1");
+        assert_eq!(&format!("{:#e}", _one_tenth_1_f), "1e-1");
         assert_eq!(&format!("{:e}", _1000_f), "1e3");
         assert_eq!(&format!("{:#e}", _1000_f), "1e3");
         assert_eq!(&format!("{:e}", _1_big_f), "1e0/3.14159e38");
         assert_eq!(&format!("{:#e}", _1_big_f), "1e0/3.14159e38");
 
-        assert_eq!(&format!("{:E}", _one_tehth_1_f), "1E-1");
-        assert_eq!(&format!("{:#E}", _one_tehth_1_f), "1E-1");
+        assert_eq!(&format!("{:E}", _one_tenth_1_f), "1E-1");
+        assert_eq!(&format!("{:#E}", _one_tenth_1_f), "1E-1");
         assert_eq!(&format!("{:E}", _1000_f), "1E3");
         assert_eq!(&format!("{:#E}", _1000_f), "1E3");
         assert_eq!(&format!("{:E}", _1_big_f), "1E0/3.14159E38");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1722,7 +1722,7 @@ mod test {
         assert_eq!(&format!("{:X}", -half_i8), "FF/2");
         assert_eq!(&format!("{:#X}", -half_i8), "0xFF/0x2");
 
-        let _one_tehth_1_f = Ratio {
+        let _one_tenth_1_f = Ratio {
             numer: 0.1_f32,
             denom: 1.0_f32,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1027,7 +1027,7 @@ macro_rules! impl_formatting {
             }
             #[cfg(not(feature = "std"))]
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-                plus = if f.sign_plus() && self.numer >= T::zero() {
+                let plus = if f.sign_plus() && self.numer >= T::zero() {
                     "+"
                 } else {
                     ""
@@ -1450,6 +1450,10 @@ mod test {
         numer: isize::MAX - 1,
         denom: 1,
     };
+    pub const _BILLION: Rational = Ratio {
+        numer: 1_000_000_000,
+        denom: 1,
+    };
 
     #[cfg(feature = "bigint")]
     pub fn to_big(n: Rational) -> BigRational {
@@ -1769,31 +1773,24 @@ mod test {
         assert_fmt_eq!(format_args!("{:X}", -half_i8), "FF/2");
         assert_fmt_eq!(format_args!("{:#X}", -half_i8), "0xFF/0x2");
 
-        let _one_tenth_1_f = Ratio {
-            numer: 0.1_f32,
-            denom: 1.0_f32,
-        };
-        let _1000_f = Ratio {
-            numer: 1000.0_f32,
-            denom: 1.0_f32,
-        };
-        let _1_big_f = Ratio {
-            numer: 1.0_f32,
-            denom: 3.14159e38,
-        };
-        // assert_fmt_eq!(format_args!("{:e}", _one_tenth_1_f), "1e-1");
-        // assert_fmt_eq!(format_args!("{:#e}", _one_tenth_1_f), "1e-1");
-        // assert_fmt_eq!(format_args!("{:e}", _1000_f), "1e3");
-        // assert_fmt_eq!(format_args!("{:#e}", _1000_f), "1e3");
-        // assert_fmt_eq!(format_args!("{:e}", _1_big_f), "1e0/3.14159e38");
-        // assert_fmt_eq!(format_args!("{:#e}", _1_big_f), "1e0/3.14159e38");
+        #[cfg(has_int_exp_fmt)]
+        {
+            assert_fmt_eq!(format_args!("{:e}", -_2), "-2e0");
+            assert_fmt_eq!(format_args!("{:#e}", -_2), "-2e0");
+            assert_fmt_eq!(format_args!("{:+e}", -_2), "-2e0");
+            assert_fmt_eq!(format_args!("{:e}", _BILLION), "1e9");
+            assert_fmt_eq!(format_args!("{:+e}", _BILLION), "+1e9");
+            assert_fmt_eq!(format_args!("{:e}", _BILLION.recip()), "1e0/1e9");
+            assert_fmt_eq!(format_args!("{:+e}", _BILLION.recip()), "+1e0/1e9");
 
-        // assert_fmt_eq!(format_args!("{:E}", _one_tenth_1_f), "1E-1");
-        // assert_fmt_eq!(format_args!("{:#E}", _one_tenth_1_f), "1E-1");
-        // assert_fmt_eq!(format_args!("{:E}", _1000_f), "1E3");
-        // assert_fmt_eq!(format_args!("{:#E}", _1000_f), "1E3");
-        // assert_fmt_eq!(format_args!("{:E}", _1_big_f), "1E0/3.14159E38");
-        // assert_fmt_eq!(format_args!("{:#E}", _1_big_f), "1E0/3.14159E38");
+            assert_fmt_eq!(format_args!("{:E}", -_2), "-2E0");
+            assert_fmt_eq!(format_args!("{:#E}", -_2), "-2E0");
+            assert_fmt_eq!(format_args!("{:+E}", -_2), "-2E0");
+            assert_fmt_eq!(format_args!("{:E}", _BILLION), "1E9");
+            assert_fmt_eq!(format_args!("{:+E}", _BILLION), "+1E9");
+            assert_fmt_eq!(format_args!("{:E}", _BILLION.recip()), "1E0/1E9");
+            assert_fmt_eq!(format_args!("{:+E}", _BILLION.recip()), "+1E0/1E9");
+        }
     }
 
     mod arith {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1007,8 +1007,7 @@ where
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        //write!(f,"{}", self.denom);
-        let non_negative = !(self < &<Ratio<T> as Zero>::zero());
+        let non_negative = *self >= Self::zero();
         let tmp = if self.denom.is_one() {
             alloc::format!("{}", self.numer)
         } else {
@@ -1020,19 +1019,6 @@ where
             f.pad_integral(non_negative, "", &tmp[1..tmp.len()])
         }
     }
-    // fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-    //     let non_negative = !(self < &<Ratio<T> as Zero>::zero());
-    //     let tmp = if self.denom.is_one() {
-    //         std::format!("{}", self.numer)
-    //     } else {
-    //         std::format!("{}/{}", self.numer, self.denom)
-    //     };
-    //     if non_negative {
-    //         f.pad_integral(non_negative, "", &tmp)
-    //     } else {
-    //         f.pad_integral(non_negative, "", &tmp[1..tmp.len()])
-    //     }
-    // }
 }
 
 impl<T> Octal for Ratio<T>
@@ -1041,7 +1027,7 @@ where
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let non_negative = !(self < &<Ratio<T> as Zero>::zero());
+        let non_negative = *self >= Self::zero();
         let prefix = "0o";
         let tmp = if self.denom.is_one() {
             alloc::format!("{:o}", self.numer)
@@ -1066,7 +1052,7 @@ where
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let non_negative = !(self < &<Ratio<T> as Zero>::zero());
+        let non_negative = *self >= Self::zero();
         let prefix = "0b";
         let tmp = if self.denom.is_one() {
             alloc::format!("{:b}", self.numer)
@@ -1091,7 +1077,7 @@ where
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let non_negative = !(self < &<Ratio<T> as Zero>::zero());
+        let non_negative = *self >= Self::zero();
         let prefix = "0x";
         let tmp = if self.denom.is_one() {
             alloc::format!("{:x}", self.numer)
@@ -1116,7 +1102,7 @@ where
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let non_negative = !(self < &<Ratio<T> as Zero>::zero());
+        let non_negative = *self >= Self::zero();
         let prefix = "0x";
         let tmp = if self.denom.is_one() {
             alloc::format!("{:X}", self.numer)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ use num_traits::{
 };
 
 mod pow;
+use fmt::{Binary, Display, Formatter, LowerHex, Octal, UpperHex};
 
 /// Represents the ratio between two numbers.
 #[derive(Copy, Clone, Debug)]
@@ -1000,16 +1001,136 @@ impl<T: Clone + Integer + Signed> Signed for Ratio<T> {
 }
 
 // String conversions
-impl<T> fmt::Display for Ratio<T>
+impl<T> Display for Ratio<T>
 where
-    T: fmt::Display + Eq + One,
+    T: Display + Clone + Integer,
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.denom.is_one() {
-            write!(f, "{}", self.numer)
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        //write!(f,"{}", self.denom);
+        let non_negative = !(self < &<Ratio<T> as Zero>::zero());
+        let tmp = if self.denom.is_one() {
+            alloc::format!("{}", self.numer)
         } else {
-            write!(f, "{}/{}", self.numer, self.denom)
+            alloc::format!("{}/{}", self.numer, self.denom)
+        };
+        if non_negative {
+            f.pad_integral(non_negative, "", &tmp)
+        } else {
+            f.pad_integral(non_negative, "", &tmp[1..tmp.len()])
+        }
+    }
+    // fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    //     let non_negative = !(self < &<Ratio<T> as Zero>::zero());
+    //     let tmp = if self.denom.is_one() {
+    //         std::format!("{}", self.numer)
+    //     } else {
+    //         std::format!("{}/{}", self.numer, self.denom)
+    //     };
+    //     if non_negative {
+    //         f.pad_integral(non_negative, "", &tmp)
+    //     } else {
+    //         f.pad_integral(non_negative, "", &tmp[1..tmp.len()])
+    //     }
+    // }
+}
+
+impl<T> Octal for Ratio<T>
+where
+    T: Octal + Clone + Integer,
+{
+    /// Renders as `numer/denom`. If denom=1, renders as numer.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let non_negative = !(self < &<Ratio<T> as Zero>::zero());
+        let prefix = "0o";
+        let tmp = if self.denom.is_one() {
+            alloc::format!("{:o}", self.numer)
+        } else {
+            if f.alternate() {
+                alloc::format!("{:o}/{:#o}", self.numer, self.denom)
+            } else {
+                alloc::format!("{:o}/{:o}", self.numer, self.denom)
+            }
+        };
+        if non_negative {
+            f.pad_integral(non_negative, prefix, &tmp)
+        } else {
+            f.pad_integral(non_negative, prefix, &tmp[1..tmp.len()])
+        }
+    }
+}
+
+impl<T> Binary for Ratio<T>
+where
+    T: Binary + Clone + Integer,
+{
+    /// Renders as `numer/denom`. If denom=1, renders as numer.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let non_negative = !(self < &<Ratio<T> as Zero>::zero());
+        let prefix = "0b";
+        let tmp = if self.denom.is_one() {
+            alloc::format!("{:b}", self.numer)
+        } else {
+            if f.alternate() {
+                alloc::format!("{:b}/{:#b}", self.numer, self.denom)
+            } else {
+                alloc::format!("{:b}/{:b}", self.numer, self.denom)
+            }
+        };
+        if non_negative {
+            f.pad_integral(non_negative, prefix, &tmp)
+        } else {
+            f.pad_integral(non_negative, prefix, &tmp[1..tmp.len()])
+        }
+    }
+}
+
+impl<T> LowerHex for Ratio<T>
+where
+    T: LowerHex + Clone + Integer,
+{
+    /// Renders as `numer/denom`. If denom=1, renders as numer.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let non_negative = !(self < &<Ratio<T> as Zero>::zero());
+        let prefix = "0x";
+        let tmp = if self.denom.is_one() {
+            alloc::format!("{:x}", self.numer)
+        } else {
+            if f.alternate() {
+                alloc::format!("{:x}/{:#x}", self.numer, self.denom)
+            } else {
+                alloc::format!("{:x}/{:x}", self.numer, self.denom)
+            }
+        };
+        if non_negative {
+            f.pad_integral(non_negative, prefix, &tmp)
+        } else {
+            f.pad_integral(non_negative, prefix, &tmp[1..tmp.len()])
+        }
+    }
+}
+
+impl<T> UpperHex for Ratio<T>
+where
+    T: UpperHex + Clone + Integer,
+{
+    /// Renders as `numer/denom`. If denom=1, renders as numer.
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let non_negative = !(self < &<Ratio<T> as Zero>::zero());
+        let prefix = "0x";
+        let tmp = if self.denom.is_one() {
+            alloc::format!("{:X}", self.numer)
+        } else {
+            if f.alternate() {
+                alloc::format!("{:X}/{:#X}", self.numer, self.denom)
+            } else {
+                alloc::format!("{:X}/{:X}", self.numer, self.denom)
+            }
+        };
+        if non_negative {
+            f.pad_integral(non_negative, prefix, &tmp)
+        } else {
+            f.pad_integral(non_negative, prefix, &tmp[1..tmp.len()])
         }
     }
 }
@@ -1560,11 +1681,27 @@ mod test {
     #[test]
     #[cfg(feature = "std")]
     fn test_show() {
-        use std::string::ToString;
-        assert_eq!(format!("{}", _2), "2".to_string());
-        assert_eq!(format!("{}", _1_2), "1/2".to_string());
-        assert_eq!(format!("{}", _0), "0".to_string());
-        assert_eq!(format!("{}", Ratio::from_integer(-2)), "-2".to_string());
+        // Test:
+        // :b :o :x, :X, :?
+        // alternate or not (#)
+        // positive and negative
+        // padding
+        // does not test precision (i.e. truncation)
+        assert_eq!(&format!("{}", _2), "2");
+        assert_eq!(&format!("{}", _1_2), "1/2");
+        assert_eq!(&format!("{:7}", _1_2), "    1/2"); //test padding
+        assert_eq!(&format!("{}", -_1_2), "-1/2"); // test negatives
+        assert_eq!(&format!("{:7}", -_1_2), "   -1/2"); //test padding and negatives
+        assert_eq!(&format!("{:07}", -_1_2), "-0001/2");
+        assert_eq!(&format!("{}", _0), "0");
+        assert_eq!(&format!("{}", Ratio::from_integer(-2)), "-2");
+        assert_eq!(&format!("{:b}", _2), "10");
+        assert_eq!(&format!("{:b}", _1_2), "1/10");
+        assert_eq!(&format!("{:b}", _0), "0");
+        assert_eq!(&format!("{:b}", Ratio::from_integer(2)), "10");
+        assert_eq!(&format!("{:#b}", _1_2), "0b1/0b10");
+        assert_eq!(&format!("{:010b}", _1_2), "0000001/10");
+        assert_eq!(&format!("{:#010b}", _1_2), "0b001/0b10");
     }
 
     mod arith {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1015,13 +1015,15 @@ macro_rules! impl_formatting {
                         format!(concat!($fmt_str, "/", $fmt_str), self.numer, self.denom)
                     }
                 };
-                if f.sign_plus() {
-                    let pre_pad = pre_pad.trim_start_matches('-');
-                    let non_negative = self.numer >= T::zero();
-                    f.pad_integral(non_negative, $prefix, pre_pad)
-                } else {
-                    f.pad_integral(true, $prefix, &pre_pad)
-                }
+                //TODO: replace with strip_prefix, when stabalized
+                let (pre_pad, non_negative) = {
+                    if pre_pad.starts_with("-") {
+                        (&pre_pad[1..], false)
+                    } else {
+                        (&pre_pad[..], true)
+                    }
+                };
+                f.pad_integral(non_negative, $prefix, pre_pad)
             }
             #[cfg(not(feature = "std"))]
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -1727,6 +1729,8 @@ mod test {
         let half_i8: Ratio<i8> = Ratio::new(1_i8, 2_i8);
         assert_fmt_eq!(format_args!("{:b}", -half_i8), "11111111/10");
         assert_fmt_eq!(format_args!("{:#b}", -half_i8), "0b11111111/0b10");
+        #[cfg(feature = "std")]
+        assert_eq!(&format!("{:05}", Ratio::new(-1_i8, 1_i8)), "-0001");
 
         assert_fmt_eq!(format_args!("{:o}", _8), "10");
         assert_fmt_eq!(format_args!("{:o}", _1_8), "1/10");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ extern crate std;
 
 use core::cmp;
 use core::fmt;
+use core::fmt::{Binary, Display, Formatter, LowerExp, LowerHex, Octal, UpperExp, UpperHex};
 use core::hash::{Hash, Hasher};
 use core::ops::{Add, Div, Mul, Neg, Rem, Sub};
 use core::str::FromStr;
@@ -43,7 +44,6 @@ use num_traits::{
 };
 
 mod pow;
-use fmt::{Binary, Display, Formatter, LowerHex, Octal, UpperHex};
 
 /// Represents the ratio between two numbers.
 #[derive(Copy, Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1019,7 +1019,7 @@ where
 #[cfg(feature = "std")]
 impl<T> Octal for Ratio<T>
 where
-    T: Octal + Clone + Integer,
+    T: Octal + Eq + One,
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -1040,7 +1040,7 @@ where
 #[cfg(feature = "std")]
 impl<T> Binary for Ratio<T>
 where
-    T: Binary + Clone + Integer,
+    T: Binary + Eq + One,
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -1063,7 +1063,7 @@ where
 #[cfg(feature = "std")]
 impl<T> LowerHex for Ratio<T>
 where
-    T: LowerHex + Clone + Integer,
+    T: LowerHex + Eq + One,
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
@@ -1084,7 +1084,7 @@ where
 #[cfg(feature = "std")]
 impl<T> UpperHex for Ratio<T>
 where
-    T: UpperHex + Clone + Integer,
+    T: UpperHex + Eq + One,
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1668,20 +1668,20 @@ mod test {
 
         let _one_tehth_1_f = Ratio{numer:0.1_f32, denom:1.0_f32};
         let _1000_f = Ratio{numer:1000.0_f32, denom:1.0_f32};
-        let _1_big_f = Ratio{numer:1.0_f32, denom:std::f32::MAX};
+        let _1_big_f = Ratio{numer:1.0_f32, denom:3.14159e38};
         assert_eq!(&format!("{:e}", _one_tehth_1_f ), "1e-1");
         assert_eq!(&format!("{:#e}", _one_tehth_1_f), "1e-1");
         assert_eq!(&format!("{:e}", _1000_f), "1e3");
         assert_eq!(&format!("{:#e}", _1000_f), "1e3");
-        assert_eq!(&format!("{:e}", _1_big_f), "1e0/3.4028235e38");
-        assert_eq!(&format!("{:#e}", _1_big_f), "1e0/3.4028235e38");
+        assert_eq!(&format!("{:e}", _1_big_f), "1e0/3.14159e38");
+        assert_eq!(&format!("{:#e}", _1_big_f), "1e0/3.14159e38");
 
         assert_eq!(&format!("{:E}", _one_tehth_1_f), "1E-1");
         assert_eq!(&format!("{:#E}", _one_tehth_1_f), "1E-1");
         assert_eq!(&format!("{:E}", _1000_f), "1E3");
         assert_eq!(&format!("{:#E}", _1000_f), "1E3");
-        assert_eq!(&format!("{:E}", _1_big_f), "1E0/3.4028235E38");
-        assert_eq!(&format!("{:#E}", _1_big_f), "1E0/3.4028235E38");
+        assert_eq!(&format!("{:E}", _1_big_f), "1E0/3.14159E38");
+        assert_eq!(&format!("{:#E}", _1_big_f), "1E0/3.14159E38");
     }
 
     mod arith {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
 #![allow(clippy::suspicious_arithmetic_impl)]
 #![allow(clippy::suspicious_op_assign_impl)]
 
-
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
@@ -1002,20 +1001,6 @@ impl<T: Clone + Integer + Signed> Signed for Ratio<T> {
 }
 
 // String conversions
-impl<T> Display for Ratio<T>
-where
-    T: Display + Eq + One,
-{
-    /// Renders as `numer/denom`. If denom=1, renders as numer.
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        if self.denom.is_one() {
-            write!(f, "{}", self.numer)
-        } else {
-            write!(f, "{}/{}", self.numer, self.denom)
-        }
-    }
-}
-
 macro_rules! impl_formatting {
     ($fmt_trait:ident, $prefix:expr, $fmt_str:expr, $fmt_alt:expr) => {
         impl<T: $fmt_trait + PartialEq + One> $fmt_trait for Ratio<T> {
@@ -1048,6 +1033,7 @@ macro_rules! impl_formatting {
     };
 }
 
+impl_formatting!(Display, "", "{}", "{:#}");
 impl_formatting!(Octal, "0o", "{:o}", "{:#o}");
 impl_formatting!(Binary, "0b", "{:b}", "{:#b}");
 impl_formatting!(LowerHex, "0x", "{:x}", "{:#x}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1003,20 +1003,14 @@ impl<T: Clone + Integer + Signed> Signed for Ratio<T> {
 // String conversions
 impl<T> Display for Ratio<T>
 where
-    T: Display + Clone + Integer,
+    T: Display + Eq + One,
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let non_negative = *self >= Self::zero();
-        let tmp = if self.denom.is_one() {
-            alloc::format!("{}", self.numer)
+        if self.denom.is_one() {
+            write!(f, "{}", self.numer)
         } else {
-            alloc::format!("{}/{}", self.numer, self.denom)
-        };
-        if non_negative {
-            f.pad_integral(non_negative, "", &tmp)
-        } else {
-            f.pad_integral(non_negative, "", &tmp[1..tmp.len()])
+            write!(f, "{}/{}", self.numer, self.denom)
         }
     }
 }
@@ -1675,9 +1669,7 @@ mod test {
         // does not test precision (i.e. truncation)
         assert_eq!(&format!("{}", _2), "2");
         assert_eq!(&format!("{}", _1_2), "1/2");
-        assert_eq!(&format!("{:7}", _1_2), "    1/2"); //test padding
         assert_eq!(&format!("{}", -_1_2), "-1/2"); // test negatives
-        assert_eq!(&format!("{:7}", -_1_2), "   -1/2"); //test padding and negatives
         assert_eq!(&format!("{:07}", -_1_2), "-0001/2");
         assert_eq!(&format!("{}", _0), "0");
         assert_eq!(&format!("{}", Ratio::from_integer(-2)), "-2");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1032,7 +1032,6 @@ macro_rules! impl_formatting {
                 f.pad_integral(true, $prefix, &pre_pad)
             }
         }
-        
     };
 }
 
@@ -1666,10 +1665,19 @@ mod test {
         assert_eq!(&format!("{:X}", -half_i8), "FF/2");
         assert_eq!(&format!("{:#X}", -half_i8), "0xFF/0x2");
 
-        let _one_tehth_1_f = Ratio{numer:0.1_f32, denom:1.0_f32};
-        let _1000_f = Ratio{numer:1000.0_f32, denom:1.0_f32};
-        let _1_big_f = Ratio{numer:1.0_f32, denom:3.14159e38};
-        assert_eq!(&format!("{:e}", _one_tehth_1_f ), "1e-1");
+        let _one_tehth_1_f = Ratio {
+            numer: 0.1_f32,
+            denom: 1.0_f32,
+        };
+        let _1000_f = Ratio {
+            numer: 1000.0_f32,
+            denom: 1.0_f32,
+        };
+        let _1_big_f = Ratio {
+            numer: 1.0_f32,
+            denom: 3.14159e38,
+        };
+        assert_eq!(&format!("{:e}", _one_tehth_1_f), "1e-1");
         assert_eq!(&format!("{:#e}", _one_tehth_1_f), "1e-1");
         assert_eq!(&format!("{:e}", _1000_f), "1e3");
         assert_eq!(&format!("{:#e}", _1000_f), "1e3");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1023,9 +1023,8 @@ where
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let non_negative = *self >= Self::zero();
         let prefix = "0o";
-        let tmp = if self.denom.is_one() {
+        let pre_pad = if self.denom.is_one() {
             format!("{:o}", self.numer)
         } else {
             if f.alternate() {
@@ -1034,11 +1033,7 @@ where
                 format!("{:o}/{:o}", self.numer, self.denom)
             }
         };
-        if non_negative {
-            f.pad_integral(non_negative, prefix, &tmp)
-        } else {
-            f.pad_integral(non_negative, prefix, &tmp[1..tmp.len()])
-        }
+        f.pad_integral(true, prefix, &pre_pad)
     }
 }
 
@@ -1049,9 +1044,8 @@ where
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let non_negative = *self >= Self::zero();
         let prefix = "0b";
-        let tmp = if self.denom.is_one() {
+        let pre_pad = if self.denom.is_one() {
             format!("{:b}", self.numer)
         } else {
             if f.alternate() {
@@ -1060,11 +1054,9 @@ where
                 format!("{:b}/{:b}", self.numer, self.denom)
             }
         };
-        if non_negative {
-            f.pad_integral(non_negative, prefix, &tmp)
-        } else {
-            f.pad_integral(non_negative, prefix, &tmp[1..tmp.len()])
-        }
+        // negative numbers are printed as two's compliment
+        // with no negative sign
+        f.pad_integral(true, prefix, &pre_pad)
     }
 }
 
@@ -1075,9 +1067,8 @@ where
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let non_negative = *self >= Self::zero();
         let prefix = "0x";
-        let tmp = if self.denom.is_one() {
+        let pre_pad = if self.denom.is_one() {
             format!("{:x}", self.numer)
         } else {
             if f.alternate() {
@@ -1086,11 +1077,7 @@ where
                 format!("{:x}/{:x}", self.numer, self.denom)
             }
         };
-        if non_negative {
-            f.pad_integral(non_negative, prefix, &tmp)
-        } else {
-            f.pad_integral(non_negative, prefix, &tmp[1..tmp.len()])
-        }
+        f.pad_integral(true, prefix, &pre_pad)
     }
 }
 
@@ -1101,9 +1088,8 @@ where
 {
     /// Renders as `numer/denom`. If denom=1, renders as numer.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let non_negative = *self >= Self::zero();
         let prefix = "0x";
-        let tmp = if self.denom.is_one() {
+        let pre_pad = if self.denom.is_one() {
             format!("{:X}", self.numer)
         } else {
             if f.alternate() {
@@ -1112,11 +1098,7 @@ where
                 format!("{:X}/{:X}", self.numer, self.denom)
             }
         };
-        if non_negative {
-            f.pad_integral(non_negative, prefix, &tmp)
-        } else {
-            f.pad_integral(non_negative, prefix, &tmp[1..tmp.len()])
-        }
+        f.pad_integral(true, prefix, &pre_pad)
     }
 }
 
@@ -1676,14 +1658,17 @@ mod test {
         assert_eq!(&format!("{}", _1_2), "1/2");
         assert_eq!(&format!("{}", -_1_2), "-1/2"); // test negatives
         assert_eq!(&format!("{}", _0), "0");
-        assert_eq!(&format!("{}", Ratio::from_integer(-2)), "-2");
+        assert_eq!(&format!("{}", -_2), "-2");
         assert_eq!(&format!("{:b}", _2), "10");
         assert_eq!(&format!("{:b}", _1_2), "1/10");
         assert_eq!(&format!("{:b}", _0), "0");
-        assert_eq!(&format!("{:b}", Ratio::from_integer(2)), "10");
+        assert_eq!(&format!("{:b}", _2), "10");
         assert_eq!(&format!("{:#b}", _1_2), "0b1/0b10");
         assert_eq!(&format!("{:010b}", _1_2), "0000001/10");
         assert_eq!(&format!("{:#010b}", _1_2), "0b001/0b10");
+        let half_i8: Ratio<i8> = Ratio::new(1_i8, 2_i8);
+        assert_eq!(&format!("{:b}", -half_i8), "11111111/10");
+        assert_eq!(&format!("{:#b}", -half_i8), "0b11111111/0b10");
     }
 
     mod arith {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1025,41 +1025,30 @@ macro_rules! impl_formatting {
             }
             #[cfg(not(feature = "std"))]
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-                if f.sign_plus() && self.numer >= T::zero() {
-                    if self.denom.is_one() {
-                        if f.alternate() {
-                            write!(f, concat!("+", $fmt_alt), self.numer)
-                        } else {
-                            write!(f, concat!("+", $fmt_str), self.numer)
-                        }
+                plus = if f.sign_plus() && self.numer >= T::zero() {
+                    "+"
+                } else {
+                    ""
+                };
+                if self.denom.is_one() {
+                    if f.alternate() {
+                        write!(f, concat!("{}", $fmt_alt), plus, self.numer)
                     } else {
-                        if f.alternate() {
-                            write!(
-                                f,
-                                concat!("+", $fmt_alt, "/", $fmt_alt),
-                                self.numer, self.denom
-                            )
-                        } else {
-                            write!(
-                                f,
-                                concat!("+", $fmt_str, "/", $fmt_str),
-                                self.numer, self.denom
-                            )
-                        }
+                        write!(f, concat!("{}", $fmt_str), plus, self.numer)
                     }
                 } else {
-                    if self.denom.is_one() {
-                        if f.alternate() {
-                            write!(f, $fmt_alt, self.numer)
-                        } else {
-                            write!(f, $fmt_str, self.numer)
-                        }
+                    if f.alternate() {
+                        write!(
+                            f,
+                            concat!("{}", $fmt_alt, "/", $fmt_alt),
+                            plus, self.numer, self.denom
+                        )
                     } else {
-                        if f.alternate() {
-                            write!(f, concat!($fmt_alt, "/", $fmt_alt), self.numer, self.denom)
-                        } else {
-                            write!(f, concat!($fmt_str, "/", $fmt_str), self.numer, self.denom)
-                        }
+                        write!(
+                            f,
+                            concat!("{}", $fmt_str, "/", $fmt_str),
+                            plus, self.numer, self.denom
+                        )
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 
 
 #[cfg(feature = "std")]
-#[cfg_attr(test, macro_use)]
+#[macro_use]
 extern crate std;
 
 use core::cmp;
@@ -1026,12 +1026,12 @@ where
         let non_negative = *self >= Self::zero();
         let prefix = "0o";
         let tmp = if self.denom.is_one() {
-            std::format!("{:o}", self.numer)
+            format!("{:o}", self.numer)
         } else {
             if f.alternate() {
-                std::format!("{:o}/{:#o}", self.numer, self.denom)
+                format!("{:o}/{:#o}", self.numer, self.denom)
             } else {
-                std::format!("{:o}/{:o}", self.numer, self.denom)
+                format!("{:o}/{:o}", self.numer, self.denom)
             }
         };
         if non_negative {
@@ -1052,12 +1052,12 @@ where
         let non_negative = *self >= Self::zero();
         let prefix = "0b";
         let tmp = if self.denom.is_one() {
-            std::format!("{:b}", self.numer)
+            format!("{:b}", self.numer)
         } else {
             if f.alternate() {
-                std::format!("{:b}/{:#b}", self.numer, self.denom)
+                format!("{:b}/{:#b}", self.numer, self.denom)
             } else {
-                std::format!("{:b}/{:b}", self.numer, self.denom)
+                format!("{:b}/{:b}", self.numer, self.denom)
             }
         };
         if non_negative {
@@ -1078,12 +1078,12 @@ where
         let non_negative = *self >= Self::zero();
         let prefix = "0x";
         let tmp = if self.denom.is_one() {
-            std::format!("{:x}", self.numer)
+            format!("{:x}", self.numer)
         } else {
             if f.alternate() {
-                std::format!("{:x}/{:#x}", self.numer, self.denom)
+                format!("{:x}/{:#x}", self.numer, self.denom)
             } else {
-                std::format!("{:x}/{:x}", self.numer, self.denom)
+                format!("{:x}/{:x}", self.numer, self.denom)
             }
         };
         if non_negative {
@@ -1104,12 +1104,12 @@ where
         let non_negative = *self >= Self::zero();
         let prefix = "0x";
         let tmp = if self.denom.is_one() {
-            std::format!("{:X}", self.numer)
+            format!("{:X}", self.numer)
         } else {
             if f.alternate() {
-                std::format!("{:X}/{:#X}", self.numer, self.denom)
+                format!("{:X}/{:#X}", self.numer, self.denom)
             } else {
-                std::format!("{:X}/{:X}", self.numer, self.denom)
+                format!("{:X}/{:X}", self.numer, self.denom)
             }
         };
         if non_negative {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1017,8 +1017,8 @@ where
 }
 
 macro_rules! impl_formatting {
-    ($trait:ident, $prefix:expr, $fmt_str:expr, $fmt_alt:expr) => {
-        impl<T: $trait + PartialEq + One> $trait for Ratio<T> {
+    ($fmt_trait:ident, $prefix:expr, $fmt_str:expr, $fmt_alt:expr) => {
+        impl<T: $fmt_trait + PartialEq + One> $fmt_trait for Ratio<T> {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
                 let pre_pad = if self.denom.is_one() {
                     format!($fmt_str, self.numer)
@@ -1666,19 +1666,22 @@ mod test {
         assert_eq!(&format!("{:X}", -half_i8), "FF/2");
         assert_eq!(&format!("{:#X}", -half_i8), "0xFF/0x2");
 
-        assert_eq!(&format!("{:e}", Ratio{numer:1.0_f32, denom:1.0_f32}), "1e0");
-        assert_eq!(&format!("{:#e}", Ratio{numer:1.0_f32, denom:1.0_f32}), "1e0");
-        assert_eq!(&format!("{:e}", Ratio{numer:1000.0_f32, denom:1.0_f32}), "1e3");
-        assert_eq!(&format!("{:#e}", Ratio{numer:1000.0_f32, denom:1.0_f32}), "1e3");
-        assert_eq!(&format!("{:e}", Ratio{numer:1000.0_f32, denom:7.0_f32}), "1e3/7e0");
-        assert_eq!(&format!("{:#e}", Ratio{numer:1000.0_f32, denom:7.0_f32}), "1e3/7e0");
+        let _one_tehth_1_f = Ratio{numer:0.1_f32, denom:1.0_f32};
+        let _1000_f = Ratio{numer:1000.0_f32, denom:1.0_f32};
+        let _1_big_f = Ratio{numer:1.0_f32, denom:std::f32::MAX};
+        assert_eq!(&format!("{:e}", _one_tehth_1_f ), "1e-1");
+        assert_eq!(&format!("{:#e}", _one_tehth_1_f), "1e-1");
+        assert_eq!(&format!("{:e}", _1000_f), "1e3");
+        assert_eq!(&format!("{:#e}", _1000_f), "1e3");
+        assert_eq!(&format!("{:e}", _1_big_f), "1e0/3.4028235e38");
+        assert_eq!(&format!("{:#e}", _1_big_f), "1e0/3.4028235e38");
 
-        assert_eq!(&format!("{:E}", Ratio{numer:1.0_f32, denom:1.0_f32}), "1E0");
-        assert_eq!(&format!("{:#E}", Ratio{numer:1.0_f32, denom:1.0_f32}), "1E0");
-        assert_eq!(&format!("{:E}", Ratio{numer:1000.0_f32, denom:1.0_f32}), "1E3");
-        assert_eq!(&format!("{:#E}", Ratio{numer:1000.0_f32, denom:1.0_f32}), "1E3");
-        assert_eq!(&format!("{:E}", Ratio{numer:1000.0_f32, denom:7.0_f32}), "1E3/7E0");
-        assert_eq!(&format!("{:#E}", Ratio{numer:1000.0_f32, denom:7.0_f32}), "1E3/7E0");
+        assert_eq!(&format!("{:E}", _one_tehth_1_f), "1E-1");
+        assert_eq!(&format!("{:#E}", _one_tehth_1_f), "1E-1");
+        assert_eq!(&format!("{:E}", _1000_f), "1E3");
+        assert_eq!(&format!("{:#E}", _1000_f), "1E3");
+        assert_eq!(&format!("{:E}", _1_big_f), "1E0/3.4028235E38");
+        assert_eq!(&format!("{:#E}", _1_big_f), "1E0/3.4028235E38");
     }
 
     mod arith {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1426,7 +1426,26 @@ mod test {
         numer: -2,
         denom: 1,
     };
+    pub const _8: Rational = Ratio { numer: 8, denom: 1 };
+    pub const _15: Rational = Ratio {
+        numer: 15,
+        denom: 1,
+    };
+    pub const _16: Rational = Ratio {
+        numer: 16,
+        denom: 1,
+    };
+
     pub const _1_2: Rational = Ratio { numer: 1, denom: 2 };
+    pub const _1_8: Rational = Ratio { numer: 1, denom: 8 };
+    pub const _1_15: Rational = Ratio {
+        numer: 1,
+        denom: 15,
+    };
+    pub const _1_16: Rational = Ratio {
+        numer: 1,
+        denom: 16,
+    };
     pub const _3_2: Rational = Ratio { numer: 3, denom: 2 };
     pub const _5_2: Rational = Ratio { numer: 5, denom: 2 };
     pub const _NEG1_2: Rational = Ratio {
@@ -1662,13 +1681,43 @@ mod test {
         assert_eq!(&format!("{:b}", _2), "10");
         assert_eq!(&format!("{:b}", _1_2), "1/10");
         assert_eq!(&format!("{:b}", _0), "0");
-        assert_eq!(&format!("{:b}", _2), "10");
         assert_eq!(&format!("{:#b}", _1_2), "0b1/0b10");
         assert_eq!(&format!("{:010b}", _1_2), "0000001/10");
         assert_eq!(&format!("{:#010b}", _1_2), "0b001/0b10");
         let half_i8: Ratio<i8> = Ratio::new(1_i8, 2_i8);
         assert_eq!(&format!("{:b}", -half_i8), "11111111/10");
         assert_eq!(&format!("{:#b}", -half_i8), "0b11111111/0b10");
+
+        assert_eq!(&format!("{:o}", _8), "10");
+        assert_eq!(&format!("{:o}", _1_8), "1/10");
+        assert_eq!(&format!("{:o}", _0), "0");
+        assert_eq!(&format!("{:#o}", _1_8), "0o1/0o10");
+        assert_eq!(&format!("{:010o}", _1_8), "0000001/10");
+        assert_eq!(&format!("{:#010o}", _1_8), "0o001/0o10");
+        assert_eq!(&format!("{:o}", -half_i8), "377/2");
+        assert_eq!(&format!("{:#o}", -half_i8), "0o377/0o2");
+
+        assert_eq!(&format!("{:x}", _16), "10");
+        assert_eq!(&format!("{:x}", _15), "f");
+        assert_eq!(&format!("{:x}", _1_16), "1/10");
+        assert_eq!(&format!("{:x}", _1_15), "1/f");
+        assert_eq!(&format!("{:x}", _0), "0");
+        assert_eq!(&format!("{:#x}", _1_16), "0x1/0x10");
+        assert_eq!(&format!("{:010x}", _1_16), "0000001/10");
+        assert_eq!(&format!("{:#010x}", _1_16), "0x001/0x10");
+        assert_eq!(&format!("{:x}", -half_i8), "ff/2");
+        assert_eq!(&format!("{:#x}", -half_i8), "0xff/0x2");
+
+        assert_eq!(&format!("{:X}", _16), "10");
+        assert_eq!(&format!("{:X}", _15), "F");
+        assert_eq!(&format!("{:X}", _1_16), "1/10");
+        assert_eq!(&format!("{:X}", _1_15), "1/F");
+        assert_eq!(&format!("{:X}", _0), "0");
+        assert_eq!(&format!("{:#X}", _1_16), "0x1/0x10");
+        assert_eq!(&format!("{:010X}", _1_16), "0000001/10");
+        assert_eq!(&format!("{:#010X}", _1_16), "0x001/0x10");
+        assert_eq!(&format!("{:X}", -half_i8), "FF/2");
+        assert_eq!(&format!("{:#X}", -half_i8), "0xFF/0x2");
     }
 
     mod arith {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 #![allow(clippy::suspicious_arithmetic_impl)]
 #![allow(clippy::suspicious_op_assign_impl)]
 
+
 #[cfg(feature = "std")]
 #[cfg_attr(test, macro_use)]
 extern crate std;
@@ -1015,6 +1016,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> Octal for Ratio<T>
 where
     T: Octal + Clone + Integer,
@@ -1024,12 +1026,12 @@ where
         let non_negative = *self >= Self::zero();
         let prefix = "0o";
         let tmp = if self.denom.is_one() {
-            alloc::format!("{:o}", self.numer)
+            std::format!("{:o}", self.numer)
         } else {
             if f.alternate() {
-                alloc::format!("{:o}/{:#o}", self.numer, self.denom)
+                std::format!("{:o}/{:#o}", self.numer, self.denom)
             } else {
-                alloc::format!("{:o}/{:o}", self.numer, self.denom)
+                std::format!("{:o}/{:o}", self.numer, self.denom)
             }
         };
         if non_negative {
@@ -1040,6 +1042,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> Binary for Ratio<T>
 where
     T: Binary + Clone + Integer,
@@ -1049,12 +1052,12 @@ where
         let non_negative = *self >= Self::zero();
         let prefix = "0b";
         let tmp = if self.denom.is_one() {
-            alloc::format!("{:b}", self.numer)
+            std::format!("{:b}", self.numer)
         } else {
             if f.alternate() {
-                alloc::format!("{:b}/{:#b}", self.numer, self.denom)
+                std::format!("{:b}/{:#b}", self.numer, self.denom)
             } else {
-                alloc::format!("{:b}/{:b}", self.numer, self.denom)
+                std::format!("{:b}/{:b}", self.numer, self.denom)
             }
         };
         if non_negative {
@@ -1065,6 +1068,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> LowerHex for Ratio<T>
 where
     T: LowerHex + Clone + Integer,
@@ -1074,12 +1078,12 @@ where
         let non_negative = *self >= Self::zero();
         let prefix = "0x";
         let tmp = if self.denom.is_one() {
-            alloc::format!("{:x}", self.numer)
+            std::format!("{:x}", self.numer)
         } else {
             if f.alternate() {
-                alloc::format!("{:x}/{:#x}", self.numer, self.denom)
+                std::format!("{:x}/{:#x}", self.numer, self.denom)
             } else {
-                alloc::format!("{:x}/{:x}", self.numer, self.denom)
+                std::format!("{:x}/{:x}", self.numer, self.denom)
             }
         };
         if non_negative {
@@ -1090,6 +1094,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> UpperHex for Ratio<T>
 where
     T: UpperHex + Clone + Integer,
@@ -1099,12 +1104,12 @@ where
         let non_negative = *self >= Self::zero();
         let prefix = "0x";
         let tmp = if self.denom.is_one() {
-            alloc::format!("{:X}", self.numer)
+            std::format!("{:X}", self.numer)
         } else {
             if f.alternate() {
-                alloc::format!("{:X}/{:#X}", self.numer, self.denom)
+                std::format!("{:X}/{:#X}", self.numer, self.denom)
             } else {
-                alloc::format!("{:X}/{:X}", self.numer, self.denom)
+                std::format!("{:X}/{:X}", self.numer, self.denom)
             }
         };
         if non_negative {
@@ -1670,7 +1675,6 @@ mod test {
         assert_eq!(&format!("{}", _2), "2");
         assert_eq!(&format!("{}", _1_2), "1/2");
         assert_eq!(&format!("{}", -_1_2), "-1/2"); // test negatives
-        assert_eq!(&format!("{:07}", -_1_2), "-0001/2");
         assert_eq!(&format!("{}", _0), "0");
         assert_eq!(&format!("{}", Ratio::from_integer(-2)), "-2");
         assert_eq!(&format!("{:b}", _2), "10");


### PR DESCRIPTION
fixes #1 
TODO: 
- [X] eliminate heap use for `no_std` (does not support padding)
  - [x] add better formatting tests for `no_std`
- [X] write a macro for formatting trait impls
  - [ ] ~simplify macro for formatting trait impls using `format_args!`~