### PR TITLE
Compatible with cargo --remap-path-prefix

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,5 +16,5 @@ fn main() {
         autocfg::emit("has_const_fn");
     }
 
-    autocfg::rerun_path(file!());
+    autocfg::rerun_path("build.rs");
 }


### PR DESCRIPTION
As discussed in [num-traits issue 139](https://github.com/rust-num/num-traits/issues/139).