### PR TITLE
Update and simplify the CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,9 @@ jobs:
         ]
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
@@ -41,11 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          profile: minimal
-          override: true
           target: thumbv6m-none-eabi
       - name: Checkout
         uses: actions/checkout@v3
@@ -61,11 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.31.0
         with:
-          toolchain: 1.31.0
-          profile: minimal
-          override: true
           target: thumbv6m-none-eabi
       - name: Checkout
         uses: actions/checkout@v3
@@ -80,11 +72,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.62.0
         with:
-          toolchain: 1.42.0
-          profile: minimal
-          override: true
           components: rustfmt
       - name: Checkout
         uses: actions/checkout@v3
@@ -92,4 +81,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --all --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Test
         run: ./ci/test_full.sh
 
@@ -45,10 +43,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target thumbv6m-none-eabi --no-default-features --features "num-bigint serde"
+        run: cargo build --target thumbv6m-none-eabi --no-default-features --features "num-bigint serde"
 
   # try a target that doesn't have std at all, nor alloc
   no_std_131:
@@ -62,10 +57,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --target thumbv6m-none-eabi --no-default-features --features "serde"
+        run: cargo build --target thumbv6m-none-eabi --no-default-features --features "serde"
 
   fmt:
     name: Format
@@ -78,7 +70,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --check
+        run: cargo fmt --all --check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
           profile: minimal
           override: true
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -48,7 +48,7 @@ jobs:
           override: true
           target: thumbv6m-none-eabi
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -68,7 +68,7 @@ jobs:
           override: true
           target: thumbv6m-none-eabi
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -87,7 +87,7 @@ jobs:
           override: true
           components: rustfmt
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,54 +20,41 @@ jobs:
           nightly
         ]
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build
-        run: cargo build
-      - name: Test
-        run: ./ci/test_full.sh
+      - run: cargo build
+      - run: ./ci/test_full.sh
 
   # try a target that doesn't have std at all, but does have alloc
   no_std_stable:
     name: No Std (stable)
     runs-on: ubuntu-latest
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
           target: thumbv6m-none-eabi
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build
-        run: cargo build --target thumbv6m-none-eabi --no-default-features --features "num-bigint serde"
+      - run: cargo build --target thumbv6m-none-eabi --no-default-features --features "num-bigint serde"
 
   # try a target that doesn't have std at all, nor alloc
   no_std_131:
     name: No Std (1.31.0)
     runs-on: ubuntu-latest
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@1.31.0
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.31.0
         with:
           target: thumbv6m-none-eabi
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build
-        run: cargo build --target thumbv6m-none-eabi --no-default-features --features "serde"
+      - run: cargo build --target thumbv6m-none-eabi --no-default-features --features "serde"
 
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@1.62.0
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.62.0
         with:
           components: rustfmt
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Check formatting
-        run: cargo fmt --all --check
+      - run: cargo fmt --all --check

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -22,7 +22,7 @@ jobs:
           profile: minimal
           override: true
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -22,8 +22,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Test
         run: ./ci/test_full.sh

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -15,13 +15,9 @@ jobs:
       matrix:
         rust: [1.31.0, stable]
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build
-        run: cargo build
-      - name: Test
-        run: ./ci/test_full.sh
+      - run: cargo build
+      - run: ./ci/test_full.sh

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -16,11 +16,9 @@ jobs:
         rust: [1.31.0, stable]
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,9 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
+        run: cargo build
       - name: Test
         run: ./ci/test_full.sh
 
@@ -35,7 +33,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --check
+        run: cargo fmt --all --check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
           profile: minimal
           override: true
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -38,7 +38,7 @@ jobs:
           override: true
           components: rustfmt
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Check formatting
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,11 +12,9 @@ jobs:
         rust: [1.31.0, stable]
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
@@ -31,11 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rust install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.62.0
         with:
-          toolchain: 1.42.0
-          profile: minimal
-          override: true
           components: rustfmt
       - name: Checkout
         uses: actions/checkout@v3
@@ -43,4 +38,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --all --check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,26 +11,19 @@ jobs:
       matrix:
         rust: [1.31.0, stable]
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build
-        run: cargo build
-      - name: Test
-        run: ./ci/test_full.sh
+      - run: cargo build
+      - run: ./ci/test_full.sh
 
   fmt:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - name: Rust install
-        uses: dtolnay/rust-toolchain@1.62.0
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.62.0
         with:
           components: rustfmt
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Check formatting
-        run: cargo fmt --all --check
+      - run: cargo fmt --all --check


### PR DESCRIPTION
- Update to actions/checkout@v3
- Switch from actions-rs/toolchain to dtolnay/rust-toolchain
- Switch from actions-rs/cargo to plain run
- Stop explicitly naming CI steps
