### PR TITLE
Exposes approximate_float for unsigned ratios

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ use std::error::Error;
 use num_bigint::{BigInt, BigUint, Sign, ToBigInt};
 
 use num_integer::Integer;
+use num_traits::Unsigned;
 use num_traits::float::FloatCore;
 use num_traits::ToPrimitive;
 use num_traits::{
@@ -1277,6 +1278,16 @@ impl<T: Integer + Signed + Bounded + NumCast + Clone> Ratio<T> {
         // T::max().recip() and T::bits() or something similar.
         let epsilon = <F as NumCast>::from(10e-20).expect("Can't convert 10e-20");
         approximate_float(f, epsilon, 30)
+    }
+}
+
+impl<T: Integer + Unsigned + Bounded + NumCast + Clone> Ratio<T> {
+    pub fn approximate_float_unsigned<F: FloatCore + NumCast>(f: F) -> Option<Ratio<T>> {
+        // 1/10e-20 < 1/2**32 which seems like a good default, and 30 seems
+        // to work well. Might want to choose something based on the types in the future, e.g.
+        // T::max().recip() and T::bits() or something similar.
+        let epsilon = <F as NumCast>::from(10e-20).expect("Can't convert 10e-20");
+        approximate_float_unsigned(f, epsilon, 30)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,10 @@ use std::error::Error;
 use num_bigint::{BigInt, BigUint, Sign, ToBigInt};
 
 use num_integer::Integer;
-use num_traits::Unsigned;
 use num_traits::float::FloatCore;
-use num_traits::ToPrimitive;
 use num_traits::{
     Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Inv, Num, NumCast, One,
-    Pow, Signed, Zero,
+    Pow, Signed, ToPrimitive, Unsigned, Zero,
 };
 
 mod pow;


### PR DESCRIPTION
Hey there. Cool crate!

Any reason `approximate_float_unsigned` isn't exposed in the lib interface ? It makes it impossible to approximate into unsigned ratios. Here's a small patch that fixes that. Hope it helps!