### PR TITLE
clippy: `From` instead of `Into`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1121,9 +1121,9 @@ impl<T: FromStr + Clone + Integer> FromStr for Ratio<T> {
     }
 }
 
-impl<T> Into<(T, T)> for Ratio<T> {
-    fn into(self) -> (T, T) {
-        (self.numer, self.denom)
+impl<T> From<Ratio<T>> for (T, T) {
+    fn from(val: Ratio<T>) -> Self {
+        (val.numer, val.denom)
     }
 }
 


### PR DESCRIPTION
I didn't include this in #119 as I wasn't sure if it would require a version bump and therefore be more controversial.