### PR TITLE
Use namespaced-features to safely bump to MSRV 1.60

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,7 @@ jobs:
     strategy:
       matrix:
         rust: [
-          1.31.0, # 2018!
-          1.36.0, # alloc
+          1.60.0, # MSRV
           stable,
           beta,
           nightly
@@ -29,7 +28,7 @@ jobs:
       - run: ./ci/test_full.sh
 
   # try a target that doesn't have std at all, but does have alloc
-  no_std_stable:
+  no_std:
     name: No Std (stable)
     runs-on: ubuntu-latest
     steps:
@@ -38,21 +37,6 @@ jobs:
         with:
           target: thumbv6m-none-eabi
       - run: cargo build --target thumbv6m-none-eabi --no-default-features --features "num-bigint serde"
-
-  # try a target that doesn't have std at all, nor alloc
-  no_std_131:
-    name: No Std (1.31.0)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cargo/registry/index
-          key: cargo-1.31.0-git-index
-      - uses: dtolnay/rust-toolchain@1.31.0
-        with:
-          target: thumbv6m-none-eabi
-      - run: cargo build --target thumbv6m-none-eabi --no-default-features --features "serde"
 
   fmt:
     name: Format
@@ -69,7 +53,7 @@ jobs:
   success:
     name: Success
     runs-on: ubuntu-latest
-    needs: [test, no_std_131, no_std_stable, fmt]
+    needs: [test, no_std, fmt]
     # Github branch protection is exceedingly silly and treats "jobs skipped because a dependency
     # failed" as success. So we have to do some contortions to ensure the job fails if any of its
     # dependencies fails.

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.31.0, stable]
+        rust: [1.60.0, stable]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.31.0, stable]
+        rust: [1.60.0, stable]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/rust-num/num-rational"
 version = "0.4.1"
 readme = "README.md"
 exclude = ["/ci/*", "/.github/*"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.60"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,3 @@ std = ["num-bigint?/std", "num-integer/std", "num-traits/std"]
 num-bigint-std = ["num-bigint/std"]
 num-bigint = ["dep:num-bigint"]
 serde = ["dep:serde"]
-
-[build-dependencies]
-autocfg = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.4.1"
 readme = "README.md"
 exclude = ["/ci/*", "/.github/*"]
 edition = "2018"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 features = ["std", "num-bigint-std", "serde"]
@@ -39,9 +40,11 @@ version = "1.0.0"
 default-features = false
 
 [features]
-default = ["num-bigint-std", "std"]
-std = ["num-integer/std", "num-traits/std"]
+default = ["num-bigint", "std"]
+std = ["num-bigint?/std", "num-integer/std", "num-traits/std"]
 num-bigint-std = ["num-bigint/std"]
+num-bigint = ["dep:num-bigint"]
+serde = ["dep:serde"]
 
 [build-dependencies]
 autocfg = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crate](https://img.shields.io/crates/v/num-rational.svg)](https://crates.io/crates/num-rational)
 [![documentation](https://docs.rs/num-rational/badge.svg)](https://docs.rs/num-rational)
-[![minimum rustc 1.31](https://img.shields.io/badge/rustc-1.31+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![minimum rustc 1.60](https://img.shields.io/badge/rustc-1.60+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![build status](https://github.com/rust-num/num-rational/workflows/master/badge.svg)](https://github.com/rust-num/num-rational/actions)
 
 Generic `Rational` numbers (aka fractions) for Rust.
@@ -33,7 +33,7 @@ Release notes are available in [RELEASES.md](RELEASES.md).
 
 ## Compatibility
 
-The `num-rational` crate is tested for rustc 1.31 and greater.
+The `num-rational` crate is tested for rustc 1.60 and greater.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,0 @@
-fn main() {
-    let ac = autocfg::new();
-    if ac.probe_expression("format!(\"{:e}\", 0_isize)") {
-        println!("cargo:rustc-cfg=has_int_exp_fmt");
-    }
-
-    autocfg::rerun_path("build.rs");
-}

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -5,6 +5,6 @@
 set -ex
 
 ci=$(dirname $0)
-for version in 1.31.0 1.36.0 stable beta nightly; do
+for version in 1.60.0 stable beta nightly; do
     rustup run "$version" "$ci/test_full.sh"
 done

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -3,7 +3,7 @@
 set -e
 
 CRATE=num-rational
-MSRV=1.31
+MSRV=1.60
 
 get_rust_version() {
   local array=($(rustc --version));
@@ -28,8 +28,7 @@ if ! check_version $MSRV ; then
 fi
 
 STD_FEATURES=(num-bigint-std serde)
-NO_STD_FEATURES=(serde)
-check_version 1.36 && NO_STD_FEATURES+=(num-bigint)
+NO_STD_FEATURES=(num-bigint serde)
 echo "Testing supported features: ${STD_FEATURES[*]}"
 echo " no_std supported features: ${NO_STD_FEATURES[*]}"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1124,9 +1124,9 @@ impl<T: FromStr + Clone + Integer> FromStr for Ratio<T> {
     }
 }
 
-impl<T> Into<(T, T)> for Ratio<T> {
-    fn into(self) -> (T, T) {
-        (self.numer, self.denom)
+impl<T> From<Ratio<T>> for (T, T) {
+    fn from(val: Ratio<T>) -> Self {
+        (val.numer, val.denom)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ## Compatibility
 //!
-//! The `num-rational` crate is tested for rustc 1.31 and greater.
+//! The `num-rational` crate is tested for rustc 1.60 and greater.
 
 #![doc(html_root_url = "https://docs.rs/num-rational/0.4")]
 #![no_std]
@@ -73,7 +73,7 @@ pub type Rational64 = Ratio<i64>;
 /// Alias for arbitrary precision rationals.
 pub type BigRational = Ratio<BigInt>;
 
-/// These method are `const` for Rust 1.31 and later.
+/// These method are `const`.
 impl<T> Ratio<T> {
     /// Creates a `Ratio` without checking for `denom == 0` or reducing.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2111,24 +2111,21 @@ mod test {
         assert_fmt_eq!(format_args!("{:X}", -half_i8), "FF/2");
         assert_fmt_eq!(format_args!("{:#X}", -half_i8), "0xFF/0x2");
 
-        #[cfg(has_int_exp_fmt)]
-        {
-            assert_fmt_eq!(format_args!("{:e}", -_2), "-2e0");
-            assert_fmt_eq!(format_args!("{:#e}", -_2), "-2e0");
-            assert_fmt_eq!(format_args!("{:+e}", -_2), "-2e0");
-            assert_fmt_eq!(format_args!("{:e}", _BILLION), "1e9");
-            assert_fmt_eq!(format_args!("{:+e}", _BILLION), "+1e9");
-            assert_fmt_eq!(format_args!("{:e}", _BILLION.recip()), "1e0/1e9");
-            assert_fmt_eq!(format_args!("{:+e}", _BILLION.recip()), "+1e0/1e9");
+        assert_fmt_eq!(format_args!("{:e}", -_2), "-2e0");
+        assert_fmt_eq!(format_args!("{:#e}", -_2), "-2e0");
+        assert_fmt_eq!(format_args!("{:+e}", -_2), "-2e0");
+        assert_fmt_eq!(format_args!("{:e}", _BILLION), "1e9");
+        assert_fmt_eq!(format_args!("{:+e}", _BILLION), "+1e9");
+        assert_fmt_eq!(format_args!("{:e}", _BILLION.recip()), "1e0/1e9");
+        assert_fmt_eq!(format_args!("{:+e}", _BILLION.recip()), "+1e0/1e9");
 
-            assert_fmt_eq!(format_args!("{:E}", -_2), "-2E0");
-            assert_fmt_eq!(format_args!("{:#E}", -_2), "-2E0");
-            assert_fmt_eq!(format_args!("{:+E}", -_2), "-2E0");
-            assert_fmt_eq!(format_args!("{:E}", _BILLION), "1E9");
-            assert_fmt_eq!(format_args!("{:+E}", _BILLION), "+1E9");
-            assert_fmt_eq!(format_args!("{:E}", _BILLION.recip()), "1E0/1E9");
-            assert_fmt_eq!(format_args!("{:+E}", _BILLION.recip()), "+1E0/1E9");
-        }
+        assert_fmt_eq!(format_args!("{:E}", -_2), "-2E0");
+        assert_fmt_eq!(format_args!("{:#E}", -_2), "-2E0");
+        assert_fmt_eq!(format_args!("{:+E}", -_2), "-2E0");
+        assert_fmt_eq!(format_args!("{:E}", _BILLION), "1E9");
+        assert_fmt_eq!(format_args!("{:+E}", _BILLION), "+1E9");
+        assert_fmt_eq!(format_args!("{:E}", _BILLION.recip()), "1E0/1E9");
+        assert_fmt_eq!(format_args!("{:+E}", _BILLION.recip()), "+1E0/1E9");
     }
 
     mod arith {


### PR DESCRIPTION
Earlier versions won't see the incompatible updates at all!
