### PR TITLE
[0.1] Disable `rustc-serialize` derives for future compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,12 @@ rust:
   - nightly
 matrix:
   include:
-    - rust: 1.8.0
+    - rust: 1.19.0
       before_script:
-        # rand 0.3.22 started depending on rand 0.4, which requires rustc 1.15
-        # manually hacking the lockfile due to the limitations of cargo#2773
         - cargo generate-lockfile
-        - sed -i -e 's/"rand 0.[34].[0-9]\+/"rand 0.3.20/' Cargo.lock
-        - sed -i -e '/^name = "rand"/,/^$/s/version = "0.3.[0-9]\+"/version = "0.3.20"/' Cargo.lock
+        - cargo update -p num-integer --precise 0.1.45
+        - cargo update -p num-traits --precise 0.2.15
+        - cargo update -p libc --precise 0.2.163
 sudo: false
 script:
   - cargo build --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,15 @@ categories = [ "algorithms", "data-structures", "science" ]
 license = "MIT/Apache-2.0"
 name = "num-rational"
 repository = "https://github.com/rust-num/num-rational"
-version = "0.1.42"
+version = "0.1.43"
 readme = "README.md"
+build = "build.rs"
 
 [dependencies]
 
 [dependencies.num-bigint]
 optional = true
-version = "0.1.42"
+version = "0.1.45"
 
 [dependencies.num-integer]
 version = "0.1.36"
@@ -37,3 +38,6 @@ version = ">= 0.7.0, < 0.9.0"
 [features]
 default = ["bigint", "rustc-serialize"]
 bigint = ["num-bigint"]
+
+[build-dependencies]
+autocfg = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crate](https://img.shields.io/crates/v/num-rational.svg)](https://crates.io/crates/num-rational)
 [![documentation](https://docs.rs/num-rational/badge.svg)](https://docs.rs/num-rational)
-![minimum rustc 1.8](https://img.shields.io/badge/rustc-1.8+-red.svg)
+![minimum rustc 1.19](https://img.shields.io/badge/rustc-1.19+-red.svg)
 [![Travis status](https://travis-ci.org/rust-num/num-rational.svg?branch=master)](https://travis-ci.org/rust-num/num-rational)
 
 Generic `Rational` numbers for Rust.
@@ -28,4 +28,4 @@ Release notes are available in [RELEASES.md](RELEASES.md).
 
 ## Compatibility
 
-The `num-rational` crate is tested for rustc 1.8 and greater.
+The `num-rational` crate is tested for rustc 1.19 and greater.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,9 @@
+# Release 0.1.43
+
+- [Disable `rustc-serialize` derives for future compilers.][132]
+
+[132]: https://github.com/rust-num/num-rational/pull/132
+
 # Release 0.1.42
 
 - Maintenance release to update dependencies.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,30 @@
+extern crate autocfg;
+
+fn main() {
+    autocfg::rerun_path("build.rs");
+    autocfg::emit_possibility(HAS_DERIVE);
+    if std::env::var_os("CARGO_FEATURE_RUSTC_SERIALIZE").is_some() {
+        let ac = autocfg::new();
+
+        // These built-in derives are being removed! (rust-lang/rust#134272)
+        //
+        // It's hard to directly probe for `derive(RustcDecodable, RustcEncodable)`, because that
+        // depends on the external `rustc-serialize` dependency. They're in `prelude::v1` where we
+        // can probe by path, but ironically only on relatively new versions, so we're also using
+        // *inaccessible* `rust_2024` as a proxy for older versions.
+        if ac.probe_raw(PRELUDE_DERIVE).is_ok() || !ac.probe_path(RUST_2024) {
+            autocfg::emit(HAS_DERIVE);
+        } else {
+            println!("cargo:warning=rustc-serialize is not supported by the current compiler");
+        }
+    }
+}
+
+const HAS_DERIVE: &str = "has_derive_rustc_serialize";
+
+const PRELUDE_DERIVE: &str = "
+#[allow(soft_unstable, deprecated)]
+pub use std::prelude::v1::{RustcDecodable, RustcEncodable};
+";
+
+const RUST_2024: &str = "std::prelude::rust_2024";

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -1,18 +1,17 @@
 #!/bin/sh
 # Use rustup to locally run the same suite of tests as .travis.yml.
-# (You should first install/update 1.8.0, stable, beta, and nightly.)
+# (You should first install/update 1.19.0, stable, beta, and nightly.)
 
 set -ex
 
 export TRAVIS_RUST_VERSION
-for TRAVIS_RUST_VERSION in 1.8.0 stable beta nightly; do
+for TRAVIS_RUST_VERSION in 1.19.0 stable beta nightly; do
     run="rustup run $TRAVIS_RUST_VERSION"
-    if [ "$TRAVIS_RUST_VERSION" = 1.8.0 ]; then
-      # rand 0.3.22 started depending on rand 0.4, which requires rustc 1.15
-      # manually hacking the lockfile due to the limitations of cargo#2773
-      $run cargo generate-lockfile
-      $run sed -i -e 's/"rand 0.[34].[0-9]\+/"rand 0.3.20/' Cargo.lock
-      $run sed -i -e '/^name = "rand"/,/^$/s/version = "0.3.[0-9]\+"/version = "0.3.20"/' Cargo.lock
+    $run cargo generate-lockfile
+    if [ "$TRAVIS_RUST_VERSION" = 1.19.0 ]; then
+      $run cargo update -p num-integer --precise 0.1.45
+      $run cargo update -p num-traits --precise 0.2.15
+      $run cargo update -p libc --precise 0.2.163
     fi
     $run cargo build --verbose
     $run $PWD/ci/test_full.sh

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,10 @@
 //!
 //! ## Compatibility
 //!
-//! The `num-rational` crate is tested for rustc 1.8 and greater.
+//! The `num-rational` crate is tested for rustc 1.19 and greater.
 
 #![doc(html_root_url = "https://docs.rs/num-rational/0.1")]
+#![cfg_attr(has_derive_rustc_serialize, warn(soft_unstable))] // un-deny
 
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
@@ -41,7 +42,7 @@ use traits::{FromPrimitive, Float, PrimInt, Num, Signed, Zero, One, Bounded, Num
 
 /// Represents the ratio between 2 numbers.
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(has_derive_rustc_serialize, derive(RustcEncodable, RustcDecodable))]
 #[allow(missing_docs)]
 pub struct Ratio<T> {
     numer: T,


### PR DESCRIPTION
The built-in derives are being [removed], but crater showed problems
with crates depending on `num v0.1`, where this feature is enabled by
default. With this PR, we detect the missing built-ins and disable the
derives, adding a build-script warning about it. Cargo won't show such
warnings by default from non-path dependencies, unless the build fails.

[removed]: https://github.com/rust-lang/rust/pull/134272
