### PR TITLE
Bump minimal version of `num-bigint` to 0.4.2 to fix minimal-versions build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ features = ["std", "num-bigint-std", "serde"]
 
 [dependencies.num-bigint]
 optional = true
-version = "0.4.0"
+version = "0.4.2"
 default-features = false
 
 [dependencies.num-integer]


### PR DESCRIPTION
Fixes #133.