### PR TITLE
Simplify to_integer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ impl<T: Clone + Integer> Ratio<T> {
     /// Converts to an integer, rounding towards zero.
     #[inline]
     pub fn to_integer(&self) -> T {
-        self.trunc().numer
+        self.numer.clone() / self.denom.clone()
     }
 
     /// Returns true if the rational number is an integer (denominator is 1).


### PR DESCRIPTION
The current code for `to_integer` calls `trunc` which calculates the integer then wraps it in a `Ratio<T>` then `to_integer` unwraps the `numer` that `trunc` returned.  This pull request skips the extra steps.

This highlights some of the absurdity in that `truc`, `round`, `floor`, and `ceil` return integers wrapped in `Ratio<T>` instead of the underlying type `T` and for 3 of those functions (`round`, `floor`, and `ceil`) there are no functions provided to get the integers directly.