### PR TITLE
minor improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ impl<T: Clone + Integer> Ratio<T> {
         };
 
         if half_or_larger {
-            let one: Ratio<T> = One::one();
+            let one: T = One::one();
             if *self >= Zero::zero() {
                 self.trunc() + one
             } else {
@@ -883,8 +883,9 @@ where
     type Output = Ratio<T>;
 
     #[inline]
-    fn neg(self) -> Ratio<T> {
-        Ratio::new_raw(-self.numer, self.denom)
+    fn neg(mut self) -> Ratio<T> {
+        self.numer = -self.numer;
+        self
     }
 }
 
@@ -908,7 +909,7 @@ where
 
     #[inline]
     fn inv(self) -> Ratio<T> {
-        self.recip()
+        self.into_recip()
     }
 }
 


### PR DESCRIPTION
In the `fn round` I changed `one` from a `Ratio<T>` to `T` because addition with a integer is quicker, avoids a `lcm` call, and some `clone` calls.

In `Neg::neg` for `Ratio<T>`, the value is changed in place. I think this might prevent some memory from being moved or allocated.

In `Inv::inv`, I changed `recip` to `into_recip` to prevent a clone operation. This is in the spirit of #110. 